### PR TITLE
Another grammar error.

### DIFF
--- a/plugins.nix
+++ b/plugins.nix
@@ -817,7 +817,7 @@ with lib;
         Size of the stickers when sending
       '';
     };
-    transformSitckers = mkOption {
+    transformStickers = mkOption {
       type = types.bool;
       default = true;
       description = ''


### PR DESCRIPTION
`i` and `t` in `transformStickers` are in the wrong position