### PR TITLE
{hm-module,docs/main.md}: add macOS support for vencord and vesktop

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -35,14 +35,14 @@ programs.nixcord.vesktopPackage
 programs.nixcord.configDir
     # path to discord config
     # type: path
-    # default: ${config.xdg.configHome}/Vencord
+    # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/Vencord
 ```
 ## vesktopConfigDir
 ```nix
 programs.nixcord.vesktopConfigDir
     # path to vesktop config
     # type: path
-    # default: ${config.xdg.configHome}/vesktop
+    # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/vesktop
 ```
 ## vencord
 ```nix

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -54,12 +54,12 @@ in {
     };
     configDir = mkOption {
       type = types.path;
-      default = "${config.xdg.configHome}/Vencord";
+      default = "${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/Vencord";
       description = "Vencord config directory";
     };
     vesktopConfigDir = mkOption {
       type = types.path;
-      default = "${config.xdg.configHome}/vesktop";
+      default = "${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/vesktop";
       description = "Config path for vesktop";
     };
     vencord.enable = mkOption {


### PR DESCRIPTION
On macOS, both Discord and Vesktop use `~/Library/Application Support` to store their config