### PR TITLE
Bump Vencord version 1.9.7 -> 1.9.8

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -111,11 +111,6 @@ programs.nixcord.config.plugins.appleMusicRichPresence.smallTextString
     # type: str
     # default: "{artist}"
 ```
-## automodContext
-```nix
-programs.nixcord.config.plugins.automodContext.enable
-    # Allows you to jump to the message surrounding an automod hit
-```
 ## banger
 ```nix
 programs.nixcord.config.plugins.banger.enable
@@ -754,11 +749,6 @@ programs.nixcord.config.plugins.loadingQuotes.additionalQuotesDelimiter
     # type: str
     # default: "|"
 ```
-## maskedLinkedPaste
-```nix
-programs.nixcord.config.plugins.maskedLinkedPaste.enable
-    # Pasting a link while having text selected will paste a hyperlink
-```
 ## memberCount
 ```nix
 programs.nixcord.config.plugins.memberCount.enable
@@ -1046,6 +1036,11 @@ programs.nixcord.config.plugins.noDevtoolsWarning.enable
 ```nix
 programs.nixcord.config.plugins.noF1.enable
     # Disables F1 help bind.
+```
+## noMaskedUrlPaste
+```nix
+programs.nixcord.config.plugins.noMaskedUrlPaste.enable
+    # Pasting a link while having text selected will not paste as masked URL
 ```
 ## noMosaic
 ```nix
@@ -1506,11 +1501,6 @@ programs.nixcord.config.plugins.shikiCodeblocks.bgOpacity
 ```nix
 programs.nixcord.config.plugins.showAllMessageButtons.enable
     # Always show all message buttons no matter if you are holding the shift key or not.
-```
-## showAllRoles
-```nix
-programs.nixcord.config.plugins.showAllRoles.enable
-    # Show all roles in new profiles.
 ```
 ## showConnections
 ```nix

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -242,17 +242,26 @@ in {
       warnings = [
         (mkIf (cfg.config.notifyAboutUpdates || cfg.config.autoUpdate || cfg.config.autoUpdateNotification) ''
           Nixcord is now pinned to a specific Vencord version to ensure compatability.
-          Config options relating to auto-update no longer function
+          Config options relating to auto-update no longer function.
+          To update Nixcord to the latest version, use nixos-rebuild
         '')
         (mkIf cfg.config.plugins.watchTogetherAdblock.enable ''
           nixcord.config.plugins.watchTogetherAdblock is deprecated and replaced by
           nixcord.config.plugins.youtubeAdblock which provides more functionality
         '')
         (mkIf cfg.config.plugins.maskedLinkPaste.enable ''
-          nixcord.config.plugins.maksedLinkPaste is now a stock Discord feature and
-          redundant. It will cease to function in the next Vencord release
+          nixcord.config.plugins.maksedLinkPaste is deprecated since it is a discord stock
+          feature and redundant.
         '')
-      ]; # notifyAboutUpdates = m
-    }    # autoUpdate = mkEnableO
-  ]);    # autoUpdateNotification
+        (mkIf cfg.config.plugins.automodContext.enable ''
+          nixcord.config.plugins.automodContext is deprecated since it is a discord stock
+          feature and redundant.
+        '')
+        (mkIf cfg.config.plugins.showAllRoles.enable ''
+          nixcord.config.plugins.showAllRoles is deprecated since it is a discord stock
+          feature and redundant.
+        '')
+      ];
+    }
+  ]);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,53 +1,53 @@
 {
     "name": "vencord",
-    "version": "1.9.7",
+    "version": "1.9.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vencord",
-            "version": "1.9.7",
+            "version": "1.9.8",
             "license": "GPL-3.0-or-later",
             "dependencies": {
-                "@sapphi-red/web-noise-suppressor": "0.3.3",
+                "@sapphi-red/web-noise-suppressor": "0.3.5",
                 "@vap/core": "0.0.12",
                 "@vap/shiki": "0.10.5",
-                "eslint-plugin-simple-header": "^1.0.2",
-                "fflate": "^0.7.4",
+                "fflate": "^0.8.2",
                 "gifenc": "github:mattdesl/gifenc#64842fca317b112a8590f8fef2bf3825da8f6fe3",
                 "monaco-editor": "^0.50.0",
-                "nanoid": "^4.0.2",
+                "nanoid": "^5.0.7",
                 "virtual-merge": "^1.0.1"
             },
             "devDependencies": {
-                "@types/chrome": "^0.0.246",
-                "@types/diff": "^5.0.3",
-                "@types/lodash": "^4.14.194",
-                "@types/node": "^18.16.3",
-                "@types/react": "^18.2.0",
-                "@types/react-dom": "^18.2.1",
-                "@types/yazl": "^2.4.2",
-                "@typescript-eslint/eslint-plugin": "^5.59.1",
-                "@typescript-eslint/parser": "^5.59.1",
-                "diff": "^5.1.0",
+                "@stylistic/eslint-plugin": "^2.6.1",
+                "@types/chrome": "^0.0.269",
+                "@types/diff": "^5.2.1",
+                "@types/lodash": "^4.17.7",
+                "@types/node": "^22.0.3",
+                "@types/react": "^18.3.3",
+                "@types/react-dom": "^18.3.0",
+                "@types/yazl": "^2.4.5",
+                "diff": "^5.2.0",
                 "discord-types": "^1.3.26",
                 "esbuild": "^0.15.18",
-                "eslint": "^8.46.0",
+                "eslint": "^9.8.0",
                 "eslint-import-resolver-alias": "^1.1.2",
-                "eslint-plugin-path-alias": "^1.0.0",
-                "eslint-plugin-simple-import-sort": "^10.0.0",
-                "eslint-plugin-unused-imports": "^2.0.0",
-                "highlight.js": "10.6.0",
+                "eslint-plugin-path-alias": "2.1.0",
+                "eslint-plugin-simple-header": "^1.1.1",
+                "eslint-plugin-simple-import-sort": "^12.1.1",
+                "eslint-plugin-unused-imports": "^4.0.1",
+                "highlight.js": "10.7.3",
                 "html-minifier-terser": "^7.2.0",
-                "moment": "^2.29.4",
-                "puppeteer-core": "^19.11.1",
+                "moment": "^2.30.1",
+                "puppeteer-core": "^22.15.0",
                 "standalone-electron-types": "^1.0.0",
-                "stylelint": "^15.6.0",
-                "stylelint-config-standard": "^33.0.0",
-                "ts-patch": "^3.1.2",
-                "tsx": "^3.12.7",
-                "type-fest": "^3.9.0",
-                "typescript": "^5.4.5",
+                "stylelint": "^16.8.1",
+                "stylelint-config-standard": "^36.0.1",
+                "ts-patch": "^3.2.1",
+                "tsx": "^4.16.5",
+                "type-fest": "^4.23.0",
+                "typescript": "^5.5.4",
+                "typescript-eslint": "^8.0.0",
                 "typescript-transform-paths": "^3.4.7",
                 "zip-local": "^0.3.5"
             },
@@ -165,9 +165,9 @@
             }
         },
         "node_modules/@csstools/css-parser-algorithms": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.7.1.tgz",
-            "integrity": "sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.1.tgz",
+            "integrity": "sha512-lSquqZCHxDfuTg/Sk2hiS0mcSFCEBuj49JfzPHJogDBT0mGCyY5A1AQzBWngitrp7i1/HAZpIgzF/VjhOEIJIg==",
             "dev": true,
             "funding": [
                 {
@@ -180,16 +180,16 @@
                 }
             ],
             "engines": {
-                "node": "^14 || ^16 || >=18"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-tokenizer": "^2.4.1"
+                "@csstools/css-tokenizer": "^3.0.1"
             }
         },
         "node_modules/@csstools/css-tokenizer": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.4.1.tgz",
-            "integrity": "sha512-eQ9DIktFJBhGjioABJRtUucoWR2mwllurfnM8LuNGAqX3ViZXaUchqk+1s7jjtkFiT9ySdACsFEA3etErkALUg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.1.tgz",
+            "integrity": "sha512-UBqaiu7kU0lfvaP982/o3khfXccVlHPWp0/vwwiIgDF0GmqqqxoiXC/6FCjlS9u92f7CoEz6nXKQnrn1kIAkOw==",
             "dev": true,
             "funding": [
                 {
@@ -202,13 +202,13 @@
                 }
             ],
             "engines": {
-                "node": "^14 || ^16 || >=18"
+                "node": ">=18"
             }
         },
         "node_modules/@csstools/media-query-list-parser": {
-            "version": "2.1.13",
-            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.13.tgz",
-            "integrity": "sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
+            "integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
             "dev": true,
             "funding": [
                 {
@@ -221,17 +221,17 @@
                 }
             ],
             "engines": {
-                "node": "^14 || ^16 || >=18"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^2.7.1",
-                "@csstools/css-tokenizer": "^2.4.1"
+                "@csstools/css-parser-algorithms": "^3.0.1",
+                "@csstools/css-tokenizer": "^3.0.1"
             }
         },
         "node_modules/@csstools/selector-specificity": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
-            "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz",
+            "integrity": "sha512-189nelqtPd8++phaHNwYovKZI0FOzH1vQEE3QhHHkNIGrg5fSs9CbYP3RvfEH5geztnIA9Jwq91wyOIwAW5JIQ==",
             "dev": true,
             "funding": [
                 {
@@ -244,10 +244,36 @@
                 }
             ],
             "engines": {
-                "node": "^14 || ^16 || >=18"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "postcss-selector-parser": "^6.0.13"
+                "postcss-selector-parser": "^6.1.0"
+            }
+        },
+        "node_modules/@dual-bundle/import-meta-resolve": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+            "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+            "dev": true,
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+            "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-arm": {
@@ -267,9 +293,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+            "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
             "cpu": [
                 "arm64"
             ],
@@ -279,13 +305,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+            "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
             "cpu": [
                 "x64"
             ],
@@ -295,13 +321,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+            "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -311,13 +337,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+            "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
             "cpu": [
                 "x64"
             ],
@@ -327,13 +353,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+            "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
             "cpu": [
                 "arm64"
             ],
@@ -343,13 +369,13 @@
                 "freebsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+            "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
             "cpu": [
                 "x64"
             ],
@@ -359,13 +385,13 @@
                 "freebsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+            "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
             "cpu": [
                 "arm"
             ],
@@ -375,13 +401,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+            "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
             "cpu": [
                 "arm64"
             ],
@@ -391,13 +417,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+            "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
             "cpu": [
                 "ia32"
             ],
@@ -407,7 +433,7 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-loong64": {
@@ -427,9 +453,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+            "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
             "cpu": [
                 "mips64el"
             ],
@@ -439,13 +465,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+            "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
             "cpu": [
                 "ppc64"
             ],
@@ -455,13 +481,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+            "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
             "cpu": [
                 "riscv64"
             ],
@@ -471,13 +497,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+            "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
             "cpu": [
                 "s390x"
             ],
@@ -487,13 +513,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+            "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
             "cpu": [
                 "x64"
             ],
@@ -503,13 +529,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+            "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
             "cpu": [
                 "x64"
             ],
@@ -519,13 +545,29 @@
                 "netbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+            "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+            "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
             "cpu": [
                 "x64"
             ],
@@ -535,13 +577,13 @@
                 "openbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+            "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
             "cpu": [
                 "x64"
             ],
@@ -551,13 +593,13 @@
                 "sunos"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+            "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
             "cpu": [
                 "arm64"
             ],
@@ -567,13 +609,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+            "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
             "cpu": [
                 "ia32"
             ],
@@ -583,13 +625,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+            "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
             "cpu": [
                 "x64"
             ],
@@ -599,7 +641,7 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -617,6 +659,18 @@
                 "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
             }
         },
+        "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/@eslint-community/regexpp": {
             "version": "4.11.0",
             "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
@@ -626,16 +680,52 @@
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
+        "node_modules/@eslint/config-array": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+            "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+            "dev": true,
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.4",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+            "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.6.0",
-                "globals": "^13.19.0",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -643,34 +733,50 @@
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@eslint/js": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.14",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
-            "deprecated": "Use @eslint/config-array instead",
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.2",
-                "debug": "^4.3.1",
-                "minimatch": "^3.0.5"
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": ">=10.10.0"
+                "node": "*"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.9.1.tgz",
+            "integrity": "sha512-xIDQRsfg5hNBqHz04H1R3scSVwmI+KUbqjsQKHKQ1DAUSaUjYPReZZmS/5PNiKu1fUvzDd6H7DEDKACSEhu+TQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+            "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -686,12 +792,18 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-            "deprecated": "Use @eslint/object-schema instead",
-            "dev": true
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
+            "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+            "dev": true,
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.5",
@@ -787,61 +899,128 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-0.5.0.tgz",
-            "integrity": "sha512-Uw6oB7VvmPRLE4iKsjuOh8zgDabhNX67dzo8U/BB0f9527qx+4eeUs+korU98OhG5C4ubg7ufBgVi63XYwS6TQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+            "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
             "dev": true,
             "dependencies": {
-                "debug": "4.3.4",
-                "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.1",
-                "progress": "2.0.3",
-                "proxy-from-env": "1.1.0",
-                "tar-fs": "2.1.1",
-                "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.1"
+                "debug": "^4.3.5",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.4.0",
+                "semver": "^7.6.3",
+                "tar-fs": "^3.0.6",
+                "unbzip2-stream": "^1.4.3",
+                "yargs": "^17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
             },
             "engines": {
-                "node": ">=14.1.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "node": ">=18"
             }
         },
         "node_modules/@sapphi-red/web-noise-suppressor": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@sapphi-red/web-noise-suppressor/-/web-noise-suppressor-0.3.3.tgz",
-            "integrity": "sha512-gAC33DCXYwNTI/k1PxOVHmbbzakUSMbb/DHpoV6rn4pKZtPI1dduULSmAAm/y1ipgIlArnk2JcnQzw4n2tCZHw=="
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@sapphi-red/web-noise-suppressor/-/web-noise-suppressor-0.3.5.tgz",
+            "integrity": "sha512-jh3+V9yM+zxLriQexoGm0GatoPaJWjs6ypFIbFYwQp+AoUb55eUXrjKtKQyuC5zShzzeAQUl0M5JzqB7SSrsRA=="
+        },
+        "node_modules/@stylistic/eslint-plugin": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-2.6.4.tgz",
+            "integrity": "sha512-euUGnjzH8EOqEYTGk9dB2OBINp0FX1nuO7/k4fO82zNRBIKZgJoDwTLM4Ce+Om6W1Qmh1PrZjCr4jh4tMEXGPQ==",
+            "dev": true,
+            "dependencies": {
+                "@stylistic/eslint-plugin-js": "2.6.4",
+                "@stylistic/eslint-plugin-jsx": "2.6.4",
+                "@stylistic/eslint-plugin-plus": "2.6.4",
+                "@stylistic/eslint-plugin-ts": "2.6.4",
+                "@types/eslint": "^9.6.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-js": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-2.6.4.tgz",
+            "integrity": "sha512-kx1hS3xTvzxZLdr/DCU/dLBE++vcP97sHeEFX2QXhk1Ipa4K1rzPOLw1HCbf4mU3s+7kHP5eYpDe+QteEOFLug==",
+            "dev": true,
+            "dependencies": {
+                "@types/eslint": "^9.6.0",
+                "acorn": "^8.12.1",
+                "eslint-visitor-keys": "^4.0.0",
+                "espree": "^10.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-jsx": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-jsx/-/eslint-plugin-jsx-2.6.4.tgz",
+            "integrity": "sha512-bIvVhdtjmyu3S10V7QRIuawtCZSq9gRmzAX23ucjCOdSFzEwlq+di0IM0riBAvvQerrJL4SM6G3xgyPs8BSXIA==",
+            "dev": true,
+            "dependencies": {
+                "@stylistic/eslint-plugin-js": "^2.6.4",
+                "@types/eslint": "^9.6.0",
+                "eslint-visitor-keys": "^4.0.0",
+                "espree": "^10.1.0",
+                "estraverse": "^5.3.0",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-plus": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-plus/-/eslint-plugin-plus-2.6.4.tgz",
+            "integrity": "sha512-EuRvtxhf7Hv8OoMIePulP/6rBJIgPTu1l5GAm1780WcF1Cl8bOZXIn84Pdac5pNv6lVlzCOFm8MD3VE+2YROuA==",
+            "dev": true,
+            "dependencies": {
+                "@types/eslint": "^9.6.0"
+            },
+            "peerDependencies": {
+                "eslint": "*"
+            }
+        },
+        "node_modules/@stylistic/eslint-plugin-ts": {
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.6.4.tgz",
+            "integrity": "sha512-yxL8Hj6WkObw1jfiLpBzKy5yfxY6vwlwO4miq34ySErUjUecPV5jxfVbOe4q1QDPKemQGPq93v7sAQS5PzM8lA==",
+            "dev": true,
+            "dependencies": {
+                "@stylistic/eslint-plugin-js": "2.6.4",
+                "@types/eslint": "^9.6.0",
+                "@typescript-eslint/utils": "^8.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "peerDependencies": {
+                "eslint": ">=8.40.0"
+            }
+        },
+        "node_modules/@tootallnate/quickjs-emscripten": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+            "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+            "dev": true
         },
         "node_modules/@types/chrome": {
-            "version": "0.0.246",
-            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.246.tgz",
-            "integrity": "sha512-MxGxEomGxsJiL9xe/7ZwVgwdn8XVKWbPvxpVQl3nWOjrS0Ce63JsfzxUc4aU3GvRcUPYsfufHmJ17BFyKxeA4g==",
+            "version": "0.0.269",
+            "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.269.tgz",
+            "integrity": "sha512-vF7x8YywnhXX2F06njQ/OE7a3Qeful43C5GUOsUksXWk89WoSFUU3iLeZW8lDpVO9atm8iZIEiLQTRC3H7NOXQ==",
             "dev": true,
             "dependencies": {
                 "@types/filesystem": "*",
@@ -852,6 +1031,22 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.1.tgz",
             "integrity": "sha512-uxpcuwWJGhe2AR1g8hD9F5OYGCqjqWnBUQFD8gMZsDbv8oPHzxJF6iMO6n8Tk0AdzlxoaaoQhOYlIg/PukVU8g==",
+            "dev": true
+        },
+        "node_modules/@types/eslint": {
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
+            "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
             "dev": true
         },
         "node_modules/@types/filesystem": {
@@ -887,26 +1082,14 @@
             "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
             "dev": true
         },
-        "node_modules/@types/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
-            "dev": true
-        },
         "node_modules/@types/node": {
-            "version": "18.19.45",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
-            "integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
+            "version": "22.5.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.0.tgz",
+            "integrity": "sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==",
             "dev": true,
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.19.2"
             }
-        },
-        "node_modules/@types/normalize-package-data": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-            "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-            "dev": true
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.12",
@@ -933,12 +1116,6 @@
                 "@types/react": "*"
             }
         },
-        "node_modules/@types/semver": {
-            "version": "7.5.8",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-            "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-            "dev": true
-        },
         "node_modules/@types/yauzl": {
             "version": "2.10.3",
             "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -959,32 +1136,31 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-            "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.2.0.tgz",
+            "integrity": "sha512-02tJIs655em7fvt9gps/+4k4OsKULYGtLBPJfOsmOq1+3cdClYiF0+d6mHu6qDnTcg88wJBkcPLpQhq7FyDz0A==",
             "dev": true,
             "dependencies": {
-                "@eslint-community/regexpp": "^4.4.0",
-                "@typescript-eslint/scope-manager": "5.62.0",
-                "@typescript-eslint/type-utils": "5.62.0",
-                "@typescript-eslint/utils": "5.62.0",
-                "debug": "^4.3.4",
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/type-utils": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "graphemer": "^1.4.0",
-                "ignore": "^5.2.0",
-                "natural-compare-lite": "^1.4.0",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "ignore": "^5.3.1",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^1.3.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^5.0.0",
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+                "eslint": "^8.57.0 || ^9.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -993,25 +1169,26 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-            "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.2.0.tgz",
+            "integrity": "sha512-j3Di+o0lHgPrb7FxL3fdEy6LJ/j2NE8u+AP/5cQ9SKb+JLH6V6UHDqJ+e0hXBkHP1wn1YDFjYCS9LBQsZDlDEg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.62.0",
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/typescript-estree": "5.62.0",
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/typescript-estree": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "eslint": "^8.57.0 || ^9.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -1020,16 +1197,16 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-            "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.2.0.tgz",
+            "integrity": "sha512-OFn80B38yD6WwpoHU2Tz/fTz7CgFqInllBoC3WP+/jLbTb4gGPTy9HBSTsbDWkMdN55XlVU0mMDYAtgvlUspGw==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/visitor-keys": "5.62.0"
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1037,25 +1214,22 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-            "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.2.0.tgz",
+            "integrity": "sha512-g1CfXGFMQdT5S+0PSO0fvGXUaiSkl73U1n9LTK5aRAFnPlJ8dLKkXr4AaLFvPedW8lVDoMgLLE3JN98ZZfsj0w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "5.62.0",
-                "@typescript-eslint/utils": "5.62.0",
+                "@typescript-eslint/typescript-estree": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0",
                 "debug": "^4.3.4",
-                "tsutils": "^3.21.0"
+                "ts-api-utils": "^1.3.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "*"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -1064,12 +1238,12 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-            "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.2.0.tgz",
+            "integrity": "sha512-6a9QSK396YqmiBKPkJtxsgZZZVjYQ6wQ/TlI0C65z7vInaETuC6HAHD98AGLC8DyIPqHytvNuS8bBVvNLKyqvQ==",
             "dev": true,
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1077,21 +1251,22 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-            "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.2.0.tgz",
+            "integrity": "sha512-kiG4EDUT4dImplOsbh47B1QnNmXSoUqOjWDvCJw/o8LgfD0yr7k2uy54D5Wm0j4t71Ge1NkynGhpWdS0dEIAUA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/visitor-keys": "5.62.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/visitor-keys": "8.2.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^1.3.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -1104,53 +1279,55 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-            "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.2.0.tgz",
+            "integrity": "sha512-O46eaYKDlV3TvAVDNcoDzd5N550ckSe8G4phko++OCSC1dYIb9LTc3HDGYdWqWIAT5qDUKphO6sd9RrpIJJPfg==",
             "dev": true,
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.2.0",
-                "@types/json-schema": "^7.0.9",
-                "@types/semver": "^7.3.12",
-                "@typescript-eslint/scope-manager": "5.62.0",
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/typescript-estree": "5.62.0",
-                "eslint-scope": "^5.1.1",
-                "semver": "^7.3.7"
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "8.2.0",
+                "@typescript-eslint/types": "8.2.0",
+                "@typescript-eslint/typescript-estree": "8.2.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "eslint": "^8.57.0 || ^9.0.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-            "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.2.0.tgz",
+            "integrity": "sha512-sbgsPMW9yLvS7IhCi8IpuK1oBmtbWUNP+hBdwl/I9nzqVsszGnNGti5r9dUtF5RLivHUFFIdRvLiTsPhzSyJ3Q==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "eslint-visitor-keys": "^3.3.0"
+                "@typescript-eslint/types": "8.2.0",
+                "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@ungap/structured-clone": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-            "dev": true
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
         },
         "node_modules/@vap/core": {
             "version": "0.0.12",
@@ -1192,15 +1369,15 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
             "dev": true,
             "dependencies": {
-                "debug": "4"
+                "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 14"
             }
         },
         "node_modules/ajv": {
@@ -1285,15 +1462,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/arrify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1301,6 +1469,18 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/ast-types": {
+            "version": "0.13.4",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+            "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/astral-regex": {
@@ -1330,11 +1510,63 @@
                 "node": ">= 4.5.0"
             }
         },
+        "node_modules/b4a": {
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+            "dev": true
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
+        },
+        "node_modules/bare-events": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+            "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/bare-fs": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
+            "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "bare-events": "^2.0.0",
+                "bare-path": "^2.0.0",
+                "bare-stream": "^2.0.0"
+            }
+        },
+        "node_modules/bare-os": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
+            "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
+            "dev": true,
+            "optional": true
+        },
+        "node_modules/bare-path": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "bare-os": "^2.1.0"
+            }
+        },
+        "node_modules/bare-stream": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
+            "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "streamx": "^2.18.0"
+            }
         },
         "node_modules/base": {
             "version": "0.11.2",
@@ -1386,25 +1618,22 @@
                 }
             ]
         },
-        "node_modules/bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+        "node_modules/basic-ftp": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
             "dev": true,
-            "dependencies": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/braces": {
@@ -1497,48 +1726,6 @@
                 "tslib": "^2.0.3"
             }
         },
-        "node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/camelcase-keys": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-            "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
-            "dev": true,
-            "dependencies": {
-                "camelcase": "^6.3.0",
-                "map-obj": "^4.1.0",
-                "quick-lru": "^5.1.1",
-                "type-fest": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/camelcase-keys/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1555,19 +1742,15 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "dev": true
-        },
         "node_modules/chromium-bidi": {
-            "version": "0.4.7",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.7.tgz",
-            "integrity": "sha512-6+mJuFXwTMU6I3vYLs6IL8A1DyQTPjCfIL971X0aMPVGRbGnNfl6i6Cl0NMbxi2bRYLGESt9T2ZIMRM5PAEcIQ==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+            "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
             "dev": true,
             "dependencies": {
-                "mitt": "3.0.0"
+                "mitt": "3.0.1",
+                "urlpattern-polyfill": "10.0.0",
+                "zod": "3.23.8"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -1710,15 +1893,15 @@
             }
         },
         "node_modules/cosmiconfig": {
-            "version": "8.3.6",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "dependencies": {
+                "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
-                "parse-json": "^5.2.0",
-                "path-type": "^4.0.0"
+                "parse-json": "^5.2.0"
             },
             "engines": {
                 "node": ">=14"
@@ -1733,15 +1916,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/cross-fetch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-            "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-            "dev": true,
-            "dependencies": {
-                "node-fetch": "2.6.7"
             }
         },
         "node_modules/cross-spawn": {
@@ -1798,6 +1972,15 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "dev": true
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/debug": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
@@ -1813,52 +1996,6 @@
                 "supports-color": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/decamelize": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-            "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/decamelize-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-            "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-            "dev": true,
-            "dependencies": {
-                "decamelize": "^1.1.0",
-                "map-obj": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/decamelize-keys/node_modules/decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/decamelize-keys/node_modules/map-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-            "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/decode-uri-component": {
@@ -1889,10 +2026,24 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/degenerator": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+            "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+            "dev": true,
+            "dependencies": {
+                "ast-types": "^0.13.4",
+                "escodegen": "^2.1.0",
+                "esprima": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1107588",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
-            "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==",
+            "version": "0.0.1312386",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+            "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
             "dev": true
         },
         "node_modules/diff": {
@@ -1936,18 +2087,6 @@
                 "csstype": "^3.0.2"
             }
         },
-        "node_modules/doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/dot-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -1983,6 +2122,15 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/error-ex": {
@@ -2372,42 +2520,59 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/escodegen": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+            "dev": true,
+            "dependencies": {
+                "esprima": "^4.0.1",
+                "estraverse": "^5.2.0",
+                "esutils": "^2.0.2"
+            },
+            "bin": {
+                "escodegen": "bin/escodegen.js",
+                "esgenerate": "bin/esgenerate.js"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "optionalDependencies": {
+                "source-map": "~0.6.1"
+            }
+        },
         "node_modules/eslint": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+            "version": "9.9.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.9.1.tgz",
+            "integrity": "sha512-dHvhrbfr4xFQ9/dq+jcVneZMyRYLjggWjk6RVsIiHsP8Rz6yZ8LvZ//iU4TrZF+SXWG+JkNF2OyiZRvzgRDqMg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.57.0",
-                "@humanwhocodes/config-array": "^0.11.14",
+                "@eslint-community/regexpp": "^4.11.0",
+                "@eslint/config-array": "^0.18.0",
+                "@eslint/eslintrc": "^3.1.0",
+                "@eslint/js": "9.9.1",
                 "@humanwhocodes/module-importer": "^1.0.1",
+                "@humanwhocodes/retry": "^0.3.0",
                 "@nodelib/fs.walk": "^1.2.8",
-                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.2",
-                "eslint-visitor-keys": "^3.4.3",
-                "espree": "^9.6.1",
-                "esquery": "^1.4.2",
+                "eslint-scope": "^8.0.2",
+                "eslint-visitor-keys": "^4.0.0",
+                "espree": "^10.1.0",
+                "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
+                "file-entry-cache": "^8.0.0",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.19.0",
-                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "is-path-inside": "^3.0.3",
-                "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
@@ -2421,10 +2586,18 @@
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://opencollective.com/eslint"
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-import-resolver-alias": {
@@ -2440,45 +2613,42 @@
             }
         },
         "node_modules/eslint-plugin-path-alias": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-path-alias/-/eslint-plugin-path-alias-1.1.0.tgz",
-            "integrity": "sha512-fDsuIsB11cvZ+5LDaOMEn1CkLFeOLXdvp9Mqi/9ZL2sAnVlRPKlMH3UPT7onFTWcFrNllYwrQ/+7LbzagGOA9A==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-path-alias/-/eslint-plugin-path-alias-2.1.0.tgz",
+            "integrity": "sha512-suHrHK2MmTDsmQhrZs+hvrNI2PBKAnZ4ir7y3oJLXJsjOFBfOJoQd+URqZC7ICHyNqesoZdcA0BxEG8z5p/mPw==",
             "dev": true,
             "dependencies": {
+                "find-pkg": "^2.0.0",
+                "get-tsconfig": "^4.7.5",
                 "nanomatch": "^1.2.13"
             },
             "peerDependencies": {
-                "eslint": "^7"
+                "eslint": "^8.0.0"
             }
         },
         "node_modules/eslint-plugin-simple-header": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/eslint-plugin-simple-header/-/eslint-plugin-simple-header-1.1.1.tgz",
-            "integrity": "sha512-xFK54pYcSEC2uULHTeo2aEgmTmdhZ9ry3zIV9OspLaEPb/Xg1oaFmOcmoNhk9WNJPwzUKrAmYyA8s4YDBfbD+g=="
+            "integrity": "sha512-xFK54pYcSEC2uULHTeo2aEgmTmdhZ9ry3zIV9OspLaEPb/Xg1oaFmOcmoNhk9WNJPwzUKrAmYyA8s4YDBfbD+g==",
+            "dev": true
         },
         "node_modules/eslint-plugin-simple-import-sort": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
-            "integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
+            "version": "12.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+            "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
             "dev": true,
             "peerDependencies": {
                 "eslint": ">=5.0.0"
             }
         },
         "node_modules/eslint-plugin-unused-imports": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
-            "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.3.tgz",
+            "integrity": "sha512-lqrNZIZjFMUr7P06eoKtQLwyVRibvG7N+LtfKtObYGizAAGrcqLkc3tDx+iAik2z7q0j/XI3ihjupIqxhFabFA==",
             "dev": true,
-            "dependencies": {
-                "eslint-rule-composer": "^0.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
             "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": "^5.0.0",
-                "eslint": "^8.0.0"
+                "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+                "eslint": "^9.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "@typescript-eslint/eslint-plugin": {
@@ -2486,80 +2656,84 @@
                 }
             }
         },
-        "node_modules/eslint-rule-composer": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
-            "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
         "node_modules/eslint-scope": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
-            "dependencies": {
-                "esrecurse": "^4.3.0",
-                "estraverse": "^4.1.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/eslint-visitor-keys": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-            "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint/node_modules/eslint-scope": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
+            "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
             "dev": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+        "node_modules/eslint-visitor-keys": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+            "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
             "dev": true,
             "engines": {
-                "node": ">=4.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+            "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
             "dev": true,
             "dependencies": {
-                "acorn": "^8.9.0",
+                "acorn": "^8.12.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
+                "eslint-visitor-keys": "^4.0.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
+            "bin": {
+                "esparse": "bin/esparse.js",
+                "esvalidate": "bin/esvalidate.js"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/esquery": {
@@ -2574,15 +2748,6 @@
                 "node": ">=0.10"
             }
         },
-        "node_modules/esquery/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/esrecurse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
@@ -2595,19 +2760,10 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/esrecurse/node_modules/estraverse": {
+        "node_modules/estraverse": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/estraverse": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "engines": {
                 "node": ">=4.0"
@@ -2626,6 +2782,18 @@
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        },
+        "node_modules/expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+            "dev": true,
+            "dependencies": {
+                "homedir-polyfill": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/extend-shallow": {
             "version": "3.0.2",
@@ -2664,6 +2832,12 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
+        },
+        "node_modules/fast-fifo": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+            "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
             "dev": true
         },
         "node_modules/fast-glob": {
@@ -2740,20 +2914,20 @@
             }
         },
         "node_modules/fflate": {
-            "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
-            "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
         },
         "node_modules/file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
             "dependencies": {
-                "flat-cache": "^3.0.4"
+                "flat-cache": "^4.0.0"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/fill-range": {
@@ -2763,6 +2937,30 @@
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-file-up": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/find-file-up/-/find-file-up-2.0.1.tgz",
+            "integrity": "sha512-qVdaUhYO39zmh28/JLQM5CoYN9byEOKEH4qfa8K1eNV17W0UUMJ9WgbR/hHFH+t5rcl+6RTb5UC7ck/I+uRkpQ==",
+            "dev": true,
+            "dependencies": {
+                "resolve-dir": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-pkg": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-pkg/-/find-pkg-2.0.0.tgz",
+            "integrity": "sha512-WgZ+nKbELDa6N3i/9nrHeNznm+lY3z4YfhDDWgW+5P0pdmMj26bxaxU11ookgY3NyP9GC7HvZ9etp0jRFqGEeQ==",
+            "dev": true,
+            "dependencies": {
+                "find-file-up": "^2.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -2785,17 +2983,16 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
             "dependencies": {
                 "flatted": "^3.2.9",
-                "keyv": "^4.5.3",
-                "rimraf": "^3.0.2"
+                "keyv": "^4.5.4"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/flatted": {
@@ -2825,17 +3022,19 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
+        "node_modules/fs-extra": {
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
+            }
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -2896,6 +3095,21 @@
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
+        "node_modules/get-uri": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+            "dev": true,
+            "dependencies": {
+                "basic-ftp": "^5.0.2",
+                "data-uri-to-buffer": "^6.0.2",
+                "debug": "^4.3.4",
+                "fs-extra": "^11.2.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -2910,27 +3124,6 @@
             "resolved": "git+ssh://git@github.com/mattdesl/gifenc.git#64842fca317b112a8590f8fef2bf3825da8f6fe3",
             "integrity": "sha512-TCgWVyjxLxM20WaQQT5neiMbdt2cuFL0BngwxcK8sV9x+M6IF0x3RIETc3VRVxfmRUxzZk+Yfv1b9cLdDnTRIw=="
         },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2944,29 +3137,33 @@
             }
         },
         "node_modules/global-modules": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-            "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "dependencies": {
-                "global-prefix": "^3.0.0"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/global-prefix": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-            "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
             "dev": true,
             "dependencies": {
-                "ini": "^1.3.5",
-                "kind-of": "^6.0.2",
-                "which": "^1.3.1"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/global-prefix/node_modules/which": {
@@ -2982,27 +3179,12 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.24.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globals/node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3045,15 +3227,6 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
-        },
-        "node_modules/hard-rejection": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-            "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -3116,24 +3289,24 @@
             }
         },
         "node_modules/highlight.js": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
-            "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
             "dev": true,
             "engines": {
                 "node": "*"
             }
         },
-        "node_modules/hosted-git-info": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-            "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+        "node_modules/homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
             "dev": true,
             "dependencies": {
-                "lru-cache": "^6.0.0"
+                "parse-passwd": "^1.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=0.10.0"
             }
         },
         "node_modules/html-minifier-terser": {
@@ -3169,17 +3342,30 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/https-proxy-agent": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
             "dependencies": {
-                "agent-base": "6",
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.0.2",
                 "debug": "4"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">= 14"
             }
         },
         "node_modules/ieee754": {
@@ -3227,15 +3413,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/import-lazy": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-            "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3245,40 +3422,24 @@
                 "node": ">=0.8.19"
             }
         },
-        "node_modules/indent-string": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-            "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-            "dev": true,
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "dev": true,
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
-        },
         "node_modules/ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
+        },
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dev": true,
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/is-accessor-descriptor": {
             "version": "1.0.1",
@@ -3419,15 +3580,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-plain-obj": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3488,6 +3640,12 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+            "dev": true
+        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3517,6 +3675,18 @@
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
             "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
         },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "node_modules/jszip": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.7.0.tgz",
@@ -3545,9 +3715,9 @@
             }
         },
         "node_modules/known-css-properties": {
-            "version": "0.29.0",
-            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.29.0.tgz",
-            "integrity": "sha512-Ne7wqW7/9Cz54PDt4I3tcV+hAyat8ypyOGzYRJQfdxnnjeWsTxt1cy8pjvvKeI5kfXuyvULyeeAvwvvtAX3ayQ==",
+            "version": "0.34.0",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
+            "integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==",
             "dev": true
         },
         "node_modules/levn": {
@@ -3606,15 +3776,12 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "version": "7.18.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+            "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
             "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/map-cache": {
@@ -3624,18 +3791,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/map-obj": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-            "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/map-visit": {
@@ -3667,38 +3822,12 @@
             "dev": true
         },
         "node_modules/meow": {
-            "version": "10.1.5",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
-            "integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
-            "dev": true,
-            "dependencies": {
-                "@types/minimist": "^1.2.2",
-                "camelcase-keys": "^7.0.0",
-                "decamelize": "^5.0.0",
-                "decamelize-keys": "^1.1.0",
-                "hard-rejection": "^2.1.0",
-                "minimist-options": "4.1.0",
-                "normalize-package-data": "^3.0.2",
-                "read-pkg-up": "^8.0.0",
-                "redent": "^4.0.0",
-                "trim-newlines": "^4.0.2",
-                "type-fest": "^1.2.2",
-                "yargs-parser": "^20.2.9"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/meow/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+            "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3714,9 +3843,9 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "dependencies": {
                 "braces": "^3.0.3",
@@ -3726,25 +3855,31 @@
                 "node": ">=8.6"
             }
         },
-        "node_modules/min-indent": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
             "engines": {
-                "node": ">=4"
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": "*"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/minimist": {
@@ -3756,24 +3891,10 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/minimist-options": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-            "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-            "dev": true,
-            "dependencies": {
-                "arrify": "^1.0.1",
-                "is-plain-obj": "^1.1.0",
-                "kind-of": "^6.0.3"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/mitt": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-            "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
             "dev": true
         },
         "node_modules/mixin-deep": {
@@ -3788,12 +3909,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true
         },
         "node_modules/moment": {
             "version": "2.30.1",
@@ -3816,9 +3931,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
-            "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+            "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
             "funding": [
                 {
                     "type": "github",
@@ -3829,7 +3944,7 @@
                 "nanoid": "bin/nanoid.js"
             },
             "engines": {
-                "node": "^14 || ^16 || >=18"
+                "node": "^18 || >=20"
             }
         },
         "node_modules/nanomatch": {
@@ -3860,11 +3975,14 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
         },
-        "node_modules/natural-compare-lite": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-            "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-            "dev": true
+        "node_modules/netmask": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+            "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4.0"
+            }
         },
         "node_modules/no-case": {
             "version": "3.0.4",
@@ -3874,41 +3992,6 @@
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "dev": true,
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/normalize-package-data": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-            "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-            "dev": true,
-            "dependencies": {
-                "hosted-git-info": "^4.0.1",
-                "is-core-module": "^2.5.0",
-                "semver": "^7.3.4",
-                "validate-npm-package-license": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/normalize-path": {
@@ -4051,6 +4134,38 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/pac-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/quickjs-emscripten": "^0.23.0",
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "get-uri": "^6.0.1",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.5",
+                "pac-resolver": "^7.0.1",
+                "socks-proxy-agent": "^8.0.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/pac-resolver": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+            "dev": true,
+            "dependencies": {
+                "degenerator": "^5.0.0",
+                "netmask": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -4097,6 +4212,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/pascal-case": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -4123,15 +4247,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
@@ -4171,12 +4286,12 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -4217,19 +4332,29 @@
             "dev": true
         },
         "node_modules/postcss-safe-parser": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-            "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
+            "integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "engines": {
-                "node": ">=12.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/postcss/"
+                "node": ">=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.3.3"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-selector-parser": {
@@ -4287,6 +4412,25 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/proxy-agent": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+            "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "^4.3.4",
+                "http-proxy-agent": "^7.0.1",
+                "https-proxy-agent": "^7.0.3",
+                "lru-cache": "^7.14.1",
+                "pac-proxy-agent": "^7.0.1",
+                "proxy-from-env": "^1.1.0",
+                "socks-proxy-agent": "^8.0.2"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -4313,50 +4457,19 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "19.11.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.11.1.tgz",
-            "integrity": "sha512-qcuC2Uf0Fwdj9wNtaTZ2OvYRraXpAK+puwwVW8ofOhOgLPZyz1c68tsorfIZyCUOpyBisjr+xByu7BMbEYMepA==",
+            "version": "22.15.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+            "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
             "dev": true,
             "dependencies": {
-                "@puppeteer/browsers": "0.5.0",
-                "chromium-bidi": "0.4.7",
-                "cross-fetch": "3.1.5",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1107588",
-                "extract-zip": "2.0.1",
-                "https-proxy-agent": "5.0.1",
-                "proxy-from-env": "1.1.0",
-                "tar-fs": "2.1.1",
-                "unbzip2-stream": "1.4.3",
-                "ws": "8.13.0"
+                "@puppeteer/browsers": "2.3.0",
+                "chromium-bidi": "0.6.3",
+                "debug": "^4.3.6",
+                "devtools-protocol": "0.0.1312386",
+                "ws": "^8.18.0"
             },
             "engines": {
-                "node": ">=14.14.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "node": ">=18"
             }
         },
         "node_modules/q": {
@@ -4390,106 +4503,11 @@
                 }
             ]
         },
-        "node_modules/quick-lru": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-            "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
-            "dev": true,
-            "dependencies": {
-                "@types/normalize-package-data": "^2.4.0",
-                "normalize-package-data": "^3.0.2",
-                "parse-json": "^5.2.0",
-                "type-fest": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-            "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
-            "dev": true,
-            "dependencies": {
-                "find-up": "^5.0.0",
-                "read-pkg": "^6.0.0",
-                "type-fest": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg-up/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dev": true,
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/redent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-            "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
-            "dev": true,
-            "dependencies": {
-                "indent-string": "^5.0.0",
-                "strip-indent": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+        "node_modules/queue-tick": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+            "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+            "dev": true
         },
         "node_modules/regex-not": {
             "version": "1.0.2",
@@ -4548,6 +4566,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+            "dev": true,
+            "dependencies": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4592,22 +4623,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4630,26 +4645,6 @@
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
         },
         "node_modules/safe-regex": {
             "version": "1.1.0",
@@ -4767,6 +4762,16 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
         "node_modules/snapdragon": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -4856,6 +4861,34 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/socks": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+            "dev": true,
+            "dependencies": {
+                "ip-address": "^9.0.5",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks-proxy-agent": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+            "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^7.1.1",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4905,38 +4938,6 @@
             "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
             "dev": true
         },
-        "node_modules/spdx-correct": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-            "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-            "dev": true,
-            "dependencies": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-exceptions": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-            "dev": true
-        },
-        "node_modules/spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "dependencies": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "node_modules/spdx-license-ids": {
-            "version": "3.0.20",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-            "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
-            "dev": true
-        },
         "node_modules/split-string": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -4949,6 +4950,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+            "dev": true
+        },
         "node_modules/standalone-electron-types": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/standalone-electron-types/-/standalone-electron-types-1.0.0.tgz",
@@ -4957,6 +4964,21 @@
             "dependencies": {
                 "@types/node": "^18.8.4"
             }
+        },
+        "node_modules/standalone-electron-types/node_modules/@types/node": {
+            "version": "18.19.45",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+            "integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "node_modules/standalone-electron-types/node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "node_modules/static-extend": {
             "version": "0.1.2",
@@ -4996,13 +5018,18 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+        "node_modules/streamx": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.19.0.tgz",
+            "integrity": "sha512-5z6CNR4gtkPbwlxyEqoDGDmWIzoNJqCBt4Eac1ICP9YaIT08ct712cFj0u1rx4F8luAuL+3Qc+RFIdI4OX00kg==",
             "dev": true,
             "dependencies": {
-                "safe-buffer": "~5.2.0"
+                "fast-fifo": "^1.3.2",
+                "queue-tick": "^1.0.1",
+                "text-decoder": "^1.1.0"
+            },
+            "optionalDependencies": {
+                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string-width": {
@@ -5031,21 +5058,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/strip-indent": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-            "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
-            "dev": true,
-            "dependencies": {
-                "min-indent": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5058,89 +5070,126 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/style-search": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
-            "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
-            "dev": true
-        },
         "node_modules/stylelint": {
-            "version": "15.11.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.11.0.tgz",
-            "integrity": "sha512-78O4c6IswZ9TzpcIiQJIN49K3qNoXTM8zEJzhaTE/xRTCZswaovSEVIa/uwbOltZrk16X4jAxjaOhzz/hTm1Kw==",
+            "version": "16.8.2",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.8.2.tgz",
+            "integrity": "sha512-fInKATippQhcSm7AB+T32GpI+626yohrg33GkFT/5jzliUw5qhlwZq2UQQwgl3HsHrf09oeARi0ZwgY/UWEv9A==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/stylelint"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/stylelint"
+                }
+            ],
             "dependencies": {
-                "@csstools/css-parser-algorithms": "^2.3.1",
-                "@csstools/css-tokenizer": "^2.2.0",
-                "@csstools/media-query-list-parser": "^2.1.4",
-                "@csstools/selector-specificity": "^3.0.0",
+                "@csstools/css-parser-algorithms": "^3.0.0",
+                "@csstools/css-tokenizer": "^3.0.0",
+                "@csstools/media-query-list-parser": "^3.0.0",
+                "@csstools/selector-specificity": "^4.0.0",
+                "@dual-bundle/import-meta-resolve": "^4.1.0",
                 "balanced-match": "^2.0.0",
                 "colord": "^2.9.3",
-                "cosmiconfig": "^8.2.0",
-                "css-functions-list": "^3.2.1",
+                "cosmiconfig": "^9.0.0",
+                "css-functions-list": "^3.2.2",
                 "css-tree": "^2.3.1",
-                "debug": "^4.3.4",
-                "fast-glob": "^3.3.1",
+                "debug": "^4.3.6",
+                "fast-glob": "^3.3.2",
                 "fastest-levenshtein": "^1.0.16",
-                "file-entry-cache": "^7.0.0",
+                "file-entry-cache": "^9.0.0",
                 "global-modules": "^2.0.0",
                 "globby": "^11.1.0",
                 "globjoin": "^0.1.4",
                 "html-tags": "^3.3.1",
-                "ignore": "^5.2.4",
-                "import-lazy": "^4.0.0",
+                "ignore": "^5.3.2",
                 "imurmurhash": "^0.1.4",
                 "is-plain-object": "^5.0.0",
-                "known-css-properties": "^0.29.0",
+                "known-css-properties": "^0.34.0",
                 "mathml-tag-names": "^2.1.3",
-                "meow": "^10.1.5",
-                "micromatch": "^4.0.5",
+                "meow": "^13.2.0",
+                "micromatch": "^4.0.7",
                 "normalize-path": "^3.0.0",
-                "picocolors": "^1.0.0",
-                "postcss": "^8.4.28",
-                "postcss-resolve-nested-selector": "^0.1.1",
-                "postcss-safe-parser": "^6.0.0",
-                "postcss-selector-parser": "^6.0.13",
+                "picocolors": "^1.0.1",
+                "postcss": "^8.4.41",
+                "postcss-resolve-nested-selector": "^0.1.6",
+                "postcss-safe-parser": "^7.0.0",
+                "postcss-selector-parser": "^6.1.2",
                 "postcss-value-parser": "^4.2.0",
                 "resolve-from": "^5.0.0",
                 "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "style-search": "^0.1.0",
+                "strip-ansi": "^7.1.0",
                 "supports-hyperlinks": "^3.0.0",
                 "svg-tags": "^1.0.0",
-                "table": "^6.8.1",
+                "table": "^6.8.2",
                 "write-file-atomic": "^5.0.1"
             },
             "bin": {
                 "stylelint": "bin/stylelint.mjs"
             },
             "engines": {
-                "node": "^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/stylelint"
+                "node": ">=18.12.0"
             }
         },
         "node_modules/stylelint-config-recommended": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-12.0.0.tgz",
-            "integrity": "sha512-x6x8QNARrGO2sG6iURkzqL+Dp+4bJorPMMRNPScdvaUK8PsynriOcMW7AFDKqkWAS5wbue/u8fUT/4ynzcmqdQ==",
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
+            "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/stylelint"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/stylelint"
+                }
+            ],
+            "engines": {
+                "node": ">=18.12.0"
+            },
             "peerDependencies": {
-                "stylelint": "^15.5.0"
+                "stylelint": "^16.1.0"
             }
         },
         "node_modules/stylelint-config-standard": {
-            "version": "33.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-33.0.0.tgz",
-            "integrity": "sha512-eyxnLWoXImUn77+ODIuW9qXBDNM+ALN68L3wT1lN2oNspZ7D9NVGlNHb2QCUn4xDug6VZLsh0tF8NyoYzkgTzg==",
+            "version": "36.0.1",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
+            "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/stylelint"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/stylelint"
+                }
+            ],
             "dependencies": {
-                "stylelint-config-recommended": "^12.0.0"
+                "stylelint-config-recommended": "^14.0.1"
+            },
+            "engines": {
+                "node": ">=18.12.0"
             },
             "peerDependencies": {
-                "stylelint": "^15.5.0"
+                "stylelint": "^16.1.0"
+            }
+        },
+        "node_modules/stylelint/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
             }
         },
         "node_modules/stylelint/node_modules/balanced-match": {
@@ -5150,15 +5199,54 @@
             "dev": true
         },
         "node_modules/stylelint/node_modules/file-entry-cache": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-7.0.2.tgz",
-            "integrity": "sha512-TfW7/1iI4Cy7Y8L6iqNdZQVvdXn0f8B4QcIXmkIbtTIe/Okm/nSlHb4IwGzRVOd3WfSieCgvf5cMzEfySAIl0g==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.0.0.tgz",
+            "integrity": "sha512-6MgEugi8p2tiUhqO7GnPsmbCCzj0YRCwwaTbpGRyKZesjRSzkqkAE9fPp7V2yMs5hwfgbQLgdvSSkGNg1s5Uvw==",
             "dev": true,
             "dependencies": {
-                "flat-cache": "^3.2.0"
+                "flat-cache": "^5.0.0"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=18"
+            }
+        },
+        "node_modules/stylelint/node_modules/flat-cache": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+            "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+            "dev": true,
+            "dependencies": {
+                "flatted": "^3.3.1",
+                "keyv": "^4.5.4"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/stylelint/node_modules/global-modules": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+            "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+            "dev": true,
+            "dependencies": {
+                "global-prefix": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/stylelint/node_modules/global-prefix": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+            "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+            "dev": true,
+            "dependencies": {
+                "ini": "^1.3.5",
+                "kind-of": "^6.0.2",
+                "which": "^1.3.1"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/stylelint/node_modules/is-plain-object": {
@@ -5177,6 +5265,33 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/stylelint/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/stylelint/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
             }
         },
         "node_modules/supports-color": {
@@ -5264,31 +5379,28 @@
             "dev": true
         },
         "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
             "dev": true,
             "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
+                "tar-stream": "^3.1.5"
+            },
+            "optionalDependencies": {
+                "bare-fs": "^2.1.1",
+                "bare-path": "^2.1.0"
             }
         },
         "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "dev": true,
             "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
+                "b4a": "^1.6.4",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
             }
         },
         "node_modules/terser": {
@@ -5314,6 +5426,15 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
+        },
+        "node_modules/text-decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+            "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+            "dev": true,
+            "dependencies": {
+                "b4a": "^1.6.4"
+            }
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -5387,22 +5508,16 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true
-        },
-        "node_modules/trim-newlines": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
-            "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
+        "node_modules/ts-api-utils": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
+            "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
             "dev": true,
             "engines": {
-                "node": ">=12"
+                "node": ">=16"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+            "peerDependencies": {
+                "typescript": ">=4.2.0"
             }
         },
         "node_modules/ts-patch": {
@@ -5423,54 +5538,61 @@
                 "tspc": "bin/tspc.js"
             }
         },
-        "node_modules/tslib": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-            "dev": true
-        },
-        "node_modules/tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+        "node_modules/ts-patch/node_modules/global-prefix": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+            "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
             "dev": true,
             "dependencies": {
-                "tslib": "^1.8.1"
+                "ini": "^1.3.5",
+                "kind-of": "^6.0.2",
+                "which": "^1.3.1"
             },
             "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+                "node": ">=6"
             }
         },
-        "node_modules/tsutils/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+        "node_modules/ts-patch/node_modules/which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "which": "bin/which"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
             "dev": true
         },
         "node_modules/tsx": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-            "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
+            "version": "4.18.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.18.0.tgz",
+            "integrity": "sha512-a1jaKBSVQkd6yEc1/NI7G6yHFfefIcuf3QJST7ZEyn4oQnxLYrZR5uZAM8UrwUa3Ge8suiZHcNS1gNrEvmobqg==",
             "dev": true,
             "dependencies": {
-                "esbuild": "~0.18.20",
-                "get-tsconfig": "^4.7.2",
-                "source-map-support": "^0.5.21"
+                "esbuild": "~0.23.0",
+                "get-tsconfig": "^4.7.5"
             },
             "bin": {
                 "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.3"
             }
         },
         "node_modules/tsx/node_modules/@esbuild/android-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+            "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
             "cpu": [
                 "arm"
             ],
@@ -5480,13 +5602,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+            "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
             "cpu": [
                 "loong64"
             ],
@@ -5496,44 +5618,46 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/tsx/node_modules/esbuild": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+            "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.18.20",
-                "@esbuild/android-arm64": "0.18.20",
-                "@esbuild/android-x64": "0.18.20",
-                "@esbuild/darwin-arm64": "0.18.20",
-                "@esbuild/darwin-x64": "0.18.20",
-                "@esbuild/freebsd-arm64": "0.18.20",
-                "@esbuild/freebsd-x64": "0.18.20",
-                "@esbuild/linux-arm": "0.18.20",
-                "@esbuild/linux-arm64": "0.18.20",
-                "@esbuild/linux-ia32": "0.18.20",
-                "@esbuild/linux-loong64": "0.18.20",
-                "@esbuild/linux-mips64el": "0.18.20",
-                "@esbuild/linux-ppc64": "0.18.20",
-                "@esbuild/linux-riscv64": "0.18.20",
-                "@esbuild/linux-s390x": "0.18.20",
-                "@esbuild/linux-x64": "0.18.20",
-                "@esbuild/netbsd-x64": "0.18.20",
-                "@esbuild/openbsd-x64": "0.18.20",
-                "@esbuild/sunos-x64": "0.18.20",
-                "@esbuild/win32-arm64": "0.18.20",
-                "@esbuild/win32-ia32": "0.18.20",
-                "@esbuild/win32-x64": "0.18.20"
+                "@esbuild/aix-ppc64": "0.23.1",
+                "@esbuild/android-arm": "0.23.1",
+                "@esbuild/android-arm64": "0.23.1",
+                "@esbuild/android-x64": "0.23.1",
+                "@esbuild/darwin-arm64": "0.23.1",
+                "@esbuild/darwin-x64": "0.23.1",
+                "@esbuild/freebsd-arm64": "0.23.1",
+                "@esbuild/freebsd-x64": "0.23.1",
+                "@esbuild/linux-arm": "0.23.1",
+                "@esbuild/linux-arm64": "0.23.1",
+                "@esbuild/linux-ia32": "0.23.1",
+                "@esbuild/linux-loong64": "0.23.1",
+                "@esbuild/linux-mips64el": "0.23.1",
+                "@esbuild/linux-ppc64": "0.23.1",
+                "@esbuild/linux-riscv64": "0.23.1",
+                "@esbuild/linux-s390x": "0.23.1",
+                "@esbuild/linux-x64": "0.23.1",
+                "@esbuild/netbsd-x64": "0.23.1",
+                "@esbuild/openbsd-arm64": "0.23.1",
+                "@esbuild/openbsd-x64": "0.23.1",
+                "@esbuild/sunos-x64": "0.23.1",
+                "@esbuild/win32-arm64": "0.23.1",
+                "@esbuild/win32-ia32": "0.23.1",
+                "@esbuild/win32-x64": "0.23.1"
             }
         },
         "node_modules/type-check": {
@@ -5549,12 +5673,12 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-            "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+            "version": "4.25.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.25.0.tgz",
+            "integrity": "sha512-bRkIGlXsnGBRBQRAY56UXBm//9qH4bmJfFvq83gSz41N282df+fjy8ofcEgc1sM8geNt5cl6mC2g9Fht1cs8Aw==",
             "dev": true,
             "engines": {
-                "node": ">=14.16"
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5573,6 +5697,29 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/typescript-eslint": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.2.0.tgz",
+            "integrity": "sha512-DmnqaPcML0xYwUzgNbM1XaKXpEb7BShYf2P1tkUmmcl8hyeG7Pj08Er7R9bNy6AufabywzJcOybQAtnD/c9DGw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.2.0",
+                "@typescript-eslint/parser": "8.2.0",
+                "@typescript-eslint/utils": "8.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/typescript-transform-paths": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/typescript-transform-paths/-/typescript-transform-paths-3.5.0.tgz",
@@ -5583,15 +5730,6 @@
             },
             "peerDependencies": {
                 "typescript": ">=3.6.5"
-            }
-        },
-        "node_modules/typescript-transform-paths/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/typescript-transform-paths/node_modules/minimatch": {
@@ -5620,9 +5758,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
             "dev": true
         },
         "node_modules/union-value": {
@@ -5647,6 +5785,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/unset-value": {
@@ -5713,6 +5860,12 @@
             "deprecated": "Please see https://github.com/lydell/urix#deprecated",
             "dev": true
         },
+        "node_modules/urlpattern-polyfill": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+            "dev": true
+        },
         "node_modules/use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -5728,16 +5881,6 @@
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
-        "node_modules/validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
-            "dependencies": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-            }
-        },
         "node_modules/virtual-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/virtual-merge/-/virtual-merge-1.0.1.tgz",
@@ -5752,22 +5895,6 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
             "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dev": true,
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -5830,9 +5957,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -5859,16 +5986,10 @@
                 "node": ">=10"
             }
         },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
-        },
         "node_modules/yargs": {
-            "version": "17.7.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-            "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -5884,15 +6005,6 @@
             }
         },
         "node_modules/yargs-parser": {
-            "version": "20.2.9",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/yargs/node_modules/yargs-parser": {
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
@@ -5933,6 +6045,15 @@
                 "graceful-fs": "^4.1.3",
                 "jszip": "^2.6.1",
                 "q": "^1.4.1"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.23.8",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/plugins.nix
+++ b/plugins.nix
@@ -72,21 +72,11 @@ with lib;
     anonymiseByDefault = mkEnableOption ''
       Whether to anonymise file names by default
     '';
-    # method = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Anonymising Method
-    #     0 - Random Characters
-    #     1 - Consistent
-    #     2 - Timestamp
-    #   '';
-    # };
     method = mkOption {
       type = types.enum [
-        "randomCharacters"
-        "consistent"
-        "timestamp"
+        "randomCharacters"  # 0
+        "consistent"        # 1
+        "timestamp"         # 2
       ];
       default = "randomCharacters";
       description = ''
@@ -202,6 +192,8 @@ with lib;
       '';
     };
   };
+  # depricated
+  # TODO remove after some time
   automodContext = {
     enable = mkEnableOption ''
       Allows you to jump to the messages surrounding an automod hit
@@ -272,21 +264,11 @@ with lib;
         Keep showing guild icons in the primary guild bar folder when it
       's open in the BetterFolders sidebar'';
     };
-    # showFolderIcon = mkOption{
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Show the folder icon above the folder guilds in the BetterFolders sidebar
-    #     0 - Never
-    #     1 - Always
-    #     2 - When more than one folder is expanded
-    #   '';
-    # };
     showFolderIcon = mkOption {
       type = types.enum [
-        "never"
-        "always"
-        "moreThanOne"
+        "never"       # 0
+        "always"      # 1
+        "moreThanOne" # 2
       ];
       default = "never";
       description = ''
@@ -561,25 +543,13 @@ with lib;
         State (line 2) must be not longer than 128 characters.
       '';
     };
-    # type = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Activity type
-    #     0 - Playing
-    #     1 - Streaming
-    #     2 - Listening
-    #     3 - Watching
-    #     4 - Competing
-    #   '';
-    # };
     type = mkOption {
       type = types.enum [
-        "playing"
-        "streaming"
-        "listening"
-        "watching"
-        "competing"
+        "playing"   # 0
+        "streaming" # 1
+        "listening" # 2
+        "watching"  # 3
+        "competing" # 4
       ];
       default = "playing";
       description = ''
@@ -593,23 +563,12 @@ with lib;
         Twitch.tv or Youtube.com link (only for Streaming activity type)
       '';
     };
-    # timestampMode = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Timestamp mode
-    #     0 - None
-    #     1 - Since discord open
-    #     2 - Same as your current time
-    #     3 - Custom
-    #   '';
-    # };
     timestampMode = mkOption {
       type = types.enum [
-        "none"
-        "discordUptime"
-        "currentTime"
-        "customTime"
+        "none"          # 0
+        "discordUptime" # 1
+        "currentTime"   # 2
+        "customTime"    # 3
       ];
       default = "none";
       description = ''
@@ -719,21 +678,11 @@ with lib;
     hideButton = mkEnableOption ''
       Hides the Dearrow button from YouTube embeds
     '';
-    # replaceElements = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Choose which elements of the embed will be replaced
-    #     0 - Everything (Titles & Thumbnails)
-    #     1 - Titles
-    #     2 - Thumbnails
-    #   '';
-    # };
     replaceElements = mkOption {
       type = types.enum [
-        "everything"
-        "titles"
-        "thumbnails"
+        "everything"  # 0
+        "titles"      # 1
+        "thumbnails"  # 2
       ];
       default = "everything";
       description = ''
@@ -1206,6 +1155,8 @@ with lib;
       '';
     };
   };
+  # depricated
+  # TODO remove after some time
   maskedLinkPaste = {
     enable = mkEnableOption ''
       Pasting a link while having text selected will paste a hyperlink
@@ -1664,23 +1615,12 @@ with lib;
         Mute Guild automatically
       '';
     };
-    # messages = mkOption {
-    #   type = types.int;
-    #   default = 3;
-    #   description = ''
-    #     Server Notification Settings
-    #     0 - All messages
-    #     1 - Only @mentions
-    #     2 - Nothing
-    #     3 - Server default
-    #   '';
-    # };
     messages = mkOption {
       type = types.enum [
-        "serverDefault"
-        "all"
-        "only@Mentions"
-        "nothing"
+        "serverDefault" # 0
+        "all"           # 1
+        "only@Mentions" # 2
+        "nothing"       # 3
       ];
       default = "serverDefault";
       description = ''
@@ -1745,6 +1685,11 @@ with lib;
   noF1 = {
     enable = mkEnableOption ''
       Disables F1 help bind.
+    '';
+  };
+  noMaskedUrlPaste = {
+    enable = mkEnableOption ''
+     Pasting a link while having text selected will not paste as masked URL
     '';
   };
   noMosaic = {
@@ -1962,28 +1907,10 @@ with lib;
       Allows you to override default forum layout/sort order. you can still change it on a per-channel basis
     '';
     # I have no idea why this uses 1 based indexing, it is driving me crazy
-    # defaultLayout = mkOption {
-    #   type = types.int;
-    #   default = 1;
-    #   description = ''
-    #     Which layout to use as default
-    #     1 - List
-    #     2 - Gallery
-    #   '';
-    # };
-    # defaultSortOrder = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Which sort order to use as default
-    #     0 - Recently Active
-    #     1 - Date Posted
-    #   '';
-    # };
     defaultLayout = mkOption {
       type = types.enum [
-        "list"
-        "gallery"
+        "list"    # 1
+        "gallery" # 2
       ];
       default = "list";
       description = ''
@@ -1992,8 +1919,8 @@ with lib;
     };
     defaultSortOrder = mkOption {
       type = types.enum [
-        "recentlyActive"
-        "datePosted"
+        "recentlyActive"  # 0
+        "datePosted"      # 1
       ];
       default = "recentlyActive";
       description = ''
@@ -2005,21 +1932,11 @@ with lib;
     enable = mkEnableOption ''
       Allows you to use party mode cause the party never ends ✨
     '';
-    # superIntensePartyMode = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Party intensity
-    #     0 - Normal
-    #     1 - Better
-    #     2 - Project X
-    #   '';
-    # };
     superIntensePartyMode = mkOption {
       type = types.enum [
-        "normal"
-        "better"
-        "projectX"
+        "normal"    # 0
+        "better"    # 1
+        "projectX"  # 2
       ];
       default = "normal";
       description = ''
@@ -2055,19 +1972,10 @@ with lib;
     enable = mkEnableOption ''
       View the permissions a user or channel has, and the roles of a server
     '';
-    # permissionsSortOrder = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     The sort method used for defining which role grants an user a certain permission
-    #     0 - Highest Role
-    #     1 - Lowest Role
-    #   '';
-    # };
     permissionsSortOrder = mkOption {
       type = types.enum [
-        "highestRole"
-        "lowestRole"
+        "highestRole" # 0
+        "lowestRole"  # 1
       ];
       default = "highestRole";
       description = ''
@@ -2100,19 +2008,10 @@ with lib;
       Allows you to pin private channels to the top of your DM list.
       To pin/unpin or reorder pins, right click DMs
     '';
-    # pinOrder = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Which order should pinned DMs be displayed in?
-    #     0 - Most recent message
-    #     1 - Custom (right click channels to reorder)
-    #   '';
-    # };
     pinOrder = mkOption {
       type = types.enum [
-        "mostRecent"
-        "custom"
+        "mostRecent"  # 0
+        "custom"      # 1
       ];
       default = "mostRecent";
       description = ''
@@ -2184,20 +2083,10 @@ with lib;
         CAPITALIZED - Capitalized
       '';
     };
-    # pronounSource = mkOption {
-    #   # Are you kidding? This plugin just used a string enum!
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     Where to source pronouns from
-    #     0 - Prefer PronounDB, fall back to Discord
-    #     1 - Prefer Discord, fall back to PronounDB (might lead to inconsistency between pronouns in chat and profile)
-    #   '';
-    # };
     pronounSource = mkOption {
       type = types.enum [
-        "preferPronounDB"
-        "preferDiscord"
+        "preferPronounDB" # 0
+        "preferDiscord"   # 1
       ];
       default = "preferPronounDB";
       description = ''
@@ -2235,21 +2124,11 @@ with lib;
     enable = mkEnableOption ''
       Reply to (ctrl + up/down) and edit (ctrl + shift + up/down) messages via keybinds
     '';
-    # shouldMention = mkOption {
-    #   type = types.int;
-    #   default = 2;
-    #   description = ''
-    #     Ping reply by default
-    #     0 - Disabled
-    #     1 - Enabled
-    #     2 - Follow NoReplyMention
-    #   '';
-    # };
     shouldMention = mkOption {
       type = types.enum [
-        "followNoReplyMention"
-        "disabled"
-        "enabled"
+        "followNoReplyMention"  # 0
+        "disabled"              # 1
+        "enabled"               # 2
       ];
       default = "followNoReplyMention";
       description = ''
@@ -2454,21 +2333,11 @@ with lib;
     enable = mkEnableOption ''
       Add online friend count or server count in the server list
     '';
-    # mode = mkOption {
-    #   type = types.int;
-    #   default = 2;
-    #   description = ''
-    #     mode
-    #     1 - Only server count
-    #     2 - Only online friend count
-    #     3 - Both server and onine friend counts
-    #   '';
-    # };
     mode = mkOption {
       type = types.enum [
-        "onlyFriendCount"
-        "onlyServerCount"
-        "both"
+        "onlyFriendCount" # 1
+        "onlyServerCount" # 2
+        "both"            # 3
       ];
       default = "onlyFriendCount";
       description = ''
@@ -2534,6 +2403,8 @@ with lib;
       Always show all message buttons no matter if you are holding the shift key or not.
     '';
   };
+  # depricated
+  # TODO remove after some time
   showAllRoles = {
     enable = mkEnableOption ''
       Show all roles in new profiles.
@@ -2550,21 +2421,11 @@ with lib;
         Icon size (px)
       '';
     };
-    # iconSpacing = mkOption {
-    #   type = types.int;
-    #   default = 1;
-    #   description = ''
-    #     Icon margin
-    #     0 - Compact
-    #     1 - Cozy
-    #     2 - Roomy
-    #   '';
-    # };
     iconSpacing = mkOption {
       type = types.enum [
-        "compact"
-        "cozy"
-        "roomy"
+        "compact" # 0
+        "cozy"    # 1
+        "roomy"   # 2
       ];
       default = "cozy";
       description = ''
@@ -2583,19 +2444,10 @@ with lib;
         Hide Unreads
       '';
     };
-    # showMode = mkOption {
-    #   type = types.int;
-    #   default = 0;
-    #   description = ''
-    #     The mode used to display hidden channels.
-    #     0 - Plain style with Lock Icon instead
-    #     1 - Muted style with hidden eye icon on the right
-    #   '';
-    # };
     showMode = mkOption {
       type = types.enum [
-        "plain"
-        "muted"
+        "plain" # 0
+        "muted" # 1
       ];
       default = "plain";
       description = ''
@@ -2846,21 +2698,11 @@ with lib;
     includeBlockedUsers = mkEnableOption ''
       Whether to show the typing indicator for blocked users.
     '';
-    # indicatorMode = mkOption {
-    #   type = types.int;
-    #   default = 3;
-    #   description = ''
-    #     How should the indicator be displayed?
-    #     1 - Animated dots
-    #     2 - Avatars
-    #     3 - Avatars and animated dots
-    #   '';
-    # };
     indicatorMode = mkOption {
       type = types.enum [
-        "both"
-        "avatars"
-        "animatedDots"
+        "both"          # 1
+        "avatars"       # 2
+        "animatedDots"  # 3
       ];
       default = "both";
       description = ''
@@ -3139,6 +2981,8 @@ with lib;
       '';
     };
   };
+  # depricated
+  # TODO remove after some time
   watchTogetherAdblock = {
     enable = mkEnableOption ''
       Block ads in the YouTube WatchTogether activity via AdGuard

--- a/vencord.nix
+++ b/vencord.nix
@@ -5,8 +5,8 @@
 , buildWebExtension ? false
 }:
 let
-  version = "1.9.7";
-  gitHash = "d919cd6";
+  version = "1.9.8";
+  gitHash = "6659f2c";
 in
 buildNpmPackage rec {
   pname = "vencord";
@@ -16,7 +16,7 @@ buildNpmPackage rec {
     owner = "Vendicated";
     repo = "Vencord";
     rev = "v${version}";
-    hash = "sha256-/EBnwDjHtAXqBn1mxnYqRvQMwiN1ykBRaI4ArRO/W9o=";
+    hash = "sha256-iAsWjMwYvz/s4OkeZONMjhgUZYsUzfTAz8+Uat0LG/M=";
   };
 
   ESBUILD_BINARY_PATH = lib.getExe (esbuild.overrideAttrs (final: _: {
@@ -34,7 +34,7 @@ buildNpmPackage rec {
   npmRebuildFlags = [ "|| true" ];
 
   makeCacheWritable = true;
-  npmDepsHash = "sha256-CmS+oiDlqnQtFvG+miT3Ewj18+GvE7+4BIXKY1N/63o=";
+  npmDepsHash = "sha256-SxFImTSGgbSHpgMKoJnSNO6Ag57AzcJnKjmARIQ0ezY=";
   npmFlags = [ "--legacy-peer-deps" ];
   npmBuildScript = if buildWebExtension then "buildWeb" else "build";
   npmBuildFlags = [ "--" "--standalone" "--disable-updater" ];
@@ -53,6 +53,8 @@ buildNpmPackage rec {
     '' else ''
       cp -r dist/ $out
     '';
+
+  passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     description = "Vencord web extension";


### PR DESCRIPTION
- Updated to new Vencord numbered release
- Removed docs for deprecated plugins
- Added option and docs for noMaskedUrlPaste
- Added several warnings about deprecated plugins

Plugin option interface should not be stable since everything is now up to date with the latest release.