### PR TITLE
fix (plugins): moyai

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -146,8 +146,8 @@ programs.nixcord.parseRules.upperNames
 programs.nixcord.parseRules.lowerPluginTitles
     # plugins with lowercase names in json
     # type: listOf str
-    # example: [ "moyai" "petpet" ]
-    # only 3 plugins in main repo follow this convention
+    # example: [ "petpet" ]
+    # only 2 plugins in main repo follow this convention
     # skips the toUpper call on these specific plugin names
 ```
 ## parseRules.fakeEnums

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -145,7 +145,7 @@ in {
         type = with types; listOf str;
         description = "plugins with lowercase names in json";
         default = [];
-        example = [ "moyai" "petpet" ];
+        example = [ "petpet" ];
       };
       fakeEnums = {
         zero = mkOption {

--- a/lib.nix
+++ b/lib.nix
@@ -22,7 +22,6 @@ let
 
   lowerPluginTitles = [ # these are the only plugins with lowercase names in json
     "iLoveSpam"
-    "moyai"
     "petpet"
   ] ++ parseRules.lowerPluginTitles;
 


### PR DESCRIPTION
"Moyai" plugin is named "Moyai", not "moyai"

https://github.com/Vendicated/Vencord/blob/8890c8c6b4201121c559e671e0110b45937467c2/src/plugins/moyai/index.ts#L94