### PR TITLE
Update to 1.10.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/docs/main.md
+++ b/docs/main.md
@@ -26,9 +26,6 @@ programs.nixcord.discord.vencord.enable
 programs.nixcord.discord.openASAR.enable
     # whether to install OpenASAR with discord
     # default: true
-programs.nixcord.discord.settings
-    # Settings to be placed in discord.configDir/settings.json
-    # type: attrs
 ```
 ## vesktop
 ```nix
@@ -41,12 +38,6 @@ programs.nixcord.vesktop.configDir
     # path to vesktop config
     # type: path
     # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/vesktop
-programs.nixcord.vesktop.settings
-    # Settings to be placed in vesktop.configDir/settings.json
-    # type: attrs
-programs.nixcord.vesktop.state
-    # Settings to be placed in vesktop.configDir/state.json
-    # type: attrs
 ```
 ## configDir
 ```nix
@@ -176,4 +167,20 @@ programs.nixcord.parseRules.fakeEnums.three
 programs.nixcord.parseRules.fakeEnums.four
     # plugin strings to map to 4
     # type: listOf str
+```
+## settings.json and state.json control
+>[!WARNING]
+> Due to Vencord/Vesktop#220 this will not be possible without upstream changes.
+> Anyways the options are provided in case you figure something out or want to PR
+> Messing with these will likely cause issues since nix store is read only
+```nix
+programs.nixcord.discord.settings
+    # Settings to be placed in discord.configDir/settings.json
+    # type: attrs
+programs.nixcord.vesktop.settings
+    # Settings to be placed in vesktop.configDir/settings.json
+    # type: attrs
+programs.nixcord.vesktop.state
+    # Settings to be placed in vesktop.configDir/state.json
+    # type: attrs
 ```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -280,11 +280,16 @@ programs.nixcord.config.plugins.colorSighted.enable
 ```nix
 programs.nixcord.config.plugins.consoleJanitor.enable
     # Disables annoying console messages/errors
-programs.nixcord.config.plugins.consoleJanitor.disableNoisyLoggers
-    # Disable noisy loggers like the MessageActionCreators
+programs.nixcord.config.plugins.consoleJanitor.disableLoggers
+    # Disables Discords loggers
+    # default: true
 programs.nixcord.config.plugins.consoleJanitor.disableSpotifyLogger
     # Disable the Spotify logger, which leaks account information and access token
     # default: true
+programs.nixcord.config.plugins.consoleJanitor.whitelistedLoggers
+    # Semi colon seperated list of loggers to allow even if others are hidden
+    # type: str
+    # default: "GatewaySocket; Routing/Utils"
 ```
 ## consoleShortcuts
 ```nix
@@ -592,6 +597,11 @@ programs.nixcord.config.plugins.friendInvites.enable
 programs.nixcord.config.plugins.friendsSince.enable
     # Shows when you became friends with someone in the user popout
 ```
+## fullSearchContext
+```nix
+programs.nixcord.config.plugins.fullSearchContext.enable
+    # Makes the message context menu in message search results have all options you'd expect
+```
 ## gameActivityToggle
 ```nix
 programs.nixcord.config.plugins.gameActivityToggle.enable
@@ -599,9 +609,9 @@ programs.nixcord.config.plugins.gameActivityToggle.enable
 programs.nixcord.config.plugins.gameActivityToggle.oldIcon
     # Use the old icon style before Discord icon redesign
 ```
-## gitPaste
+## gifPaste
 ```nix
-programs.nixcord.config.plugins.gitPaste.enable
+programs.nixcord.config.plugins.gifPaste.enable
     # Makes picking a gif in the gif picker insert a link into the chatbox instead of instantly sending it
 ```
 ## greetStickerPicker
@@ -1441,14 +1451,15 @@ programs.nixcord.config.plugins.roleColorEverywhere.memberList
 programs.nixcord.config.plugins.roleColorEverywhere.voiceUsers
     # Show role colors in the voice chat user list
     # default: true
-programs.nixcord.config.plugins.roleColorEverywhere.reactorList
+programs.nixcord.config.plugins.roleColorEverywhere.reactorsList
     # Show role colors in the reactors list
     # default: true
-```
-## searchReply
-```nix
-programs.nixcord.config.plugins.searchReply.enable
-    # Adds a reply button to search results
+programs.nixcord.config.plugins.roleColorEverywhere.colorChatMessages
+    # Color chat messages based on the author's role color
+programs.nixcord.config.plugins.roleColorEverywhere.messageSaturation
+    # Intensity of message coloring.
+    # type: int
+    # default: 30
 ```
 ## secretRingToneEnabler
 ```nix
@@ -1464,7 +1475,7 @@ programs.nixcord.config.plugins.summaries.enable
     # Enables Discord's experimental Summaries feature on every server, displaying AI generated summaries of conversations
 programs.nixcord.config.plugins.summaries.summaryExpiryThresholdDays
     # The time in days before a summary is removed. Note that only up to 50 summaries are kept per channel
-    # type: number
+    # type: int
     # default: 3
 ```
 ## sendTimestamps
@@ -1768,8 +1779,11 @@ programs.nixcord.config.plugins.userVoiceShow.enable
 programs.nixcord.config.plugins.userVoiceShow.showInUserProfileModal
     # Show a user's voice channel in their profile modal
     # default: true
-programs.nixcord.config.plugins.userVoiceShow.showVoiceChannelSectionHeader
-    # Whether to show "IN A VOICE CHANNEL" above the join button
+programs.nixcord.config.plugins.showInMemberList
+    # Show a user's Voice Channel indicator in the member and DMs list
+    # default: true
+programs.nixcord.config.plugins.showInMessages
+    # Show a user's Voice Channel indicator in messages
     # default: true
 ```
 ## USRBG

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727348695,
+        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,58 +1,35 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
+    "flake-compat": {
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727348695,
+        "lastModified": 0,
         "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
-        "type": "github"
+        "path": "/nix/store/fpivx4sjcp2vk4rp9nhliln5cwcp3kc6-source",
+        "type": "path"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,5 @@
 {
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
-  outputs = { self, nixpkgs }:
-    {
-      homeManagerModules.nixcord = import ./hm-module.nix;
-    };
+  outputs = { homeManagerModules.nixcord = import ./hm-module.nix; };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,12 @@
 {
-  outputs = { self }:
-  {
-    homeManagerModules.nixcord = import ./hm-module.nix;
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        homeManagerModules.nixcord = import ./hm-module.nix {
+          inherit pkgs;
+        };
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,7 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-      in {
-        homeManagerModules.nixcord = import ./hm-module.nix {
-          inherit pkgs;
-        };
-    });
+  inputs.flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+  outputs = { self, nixpkgs }:
+    {
+      homeManagerModules.nixcord = import ./hm-module.nix;
+    };
 }

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -257,9 +257,24 @@ in {
     };
     # nixpkgs is always really far behind
     # so instead we maintain our own vencord package
-    #
-    # vencord nixpkgs is up to date for now <---
-    vencord = applyPostPatch (pkgs.vencord);
+    vencord = applyPostPatch (
+      pkgs.callPackage ./vencord.nix {
+        inherit (pkgs)
+          curl
+          esbuild
+          fetchFromGitHub
+          git
+          jq
+          lib
+          nix-update
+          node-js
+          pnpm
+          stdenv
+          writeShellScript
+          ;
+        buildWebExtension = false;
+      }
+    );
 
     isQuickCssUsed = appConfig: (cfg.config.useQuickCss || appConfig ? "useQuickCss" && appConfig.useQuickCss) && cfg.quickCss != "";
   in mkIf cfg.enable (mkMerge [
@@ -319,44 +334,7 @@ in {
     ]))
     # Warnings
     {
-      warnings = [
-        (mkIf (cfg.config.notifyAboutUpdates || cfg.config.autoUpdate || cfg.config.autoUpdateNotification) ''
-          Nixcord is now pinned to a specific Vencord version to ensure compatability. Config options relating to auto-update no longer function. To update Nixcord to the latest version, use nixos-rebuild
-        '')
-        (mkIf (!builtins.isNull cfg.package) ''
-          nixcord.package has been moved to nixcord.discord.package
-        '')
-        (mkIf (!builtins.isNull cfg.vencord.enable) ''
-          nixcord.vencord has been moved to nixcord.discord.vencord
-        '')
-        (mkIf (!builtins.isNull cfg.openASAR.enable) ''
-          nixcord.openASAR has been moved to nixcord.discord.openASAR
-        '')
-        (mkIf (!builtins.isNull cfg.vesktopPackage) ''
-          nixcord.vesktopPackage has been moved to nixcord.vesktop.package
-        '')
-        (mkIf (!builtins.isNull cfg.config.plugins.ignoreActivities.allowedIds) ''
-          nixcord.config.plugins.ignoreActivities.allowedIds is deprecated and replaced by nixcord.config.plugins.ignoreActivities.idsList
-        '')
-        (mkIf cfg.config.plugins.watchTogetherAdblock.enable ''
-          nixcord.config.plugins.watchTogetherAdblock is deprecated and replaced by nixcord.config.plugins.youtubeAdblock which provides more functionality
-        '')
-        (mkIf cfg.config.plugins.maskedLinkPaste.enable ''
-          nixcord.config.plugins.maksedLinkPaste is deprecated since it is a discord stock feature and redundant.
-        '')
-        (mkIf cfg.config.plugins.automodContext.enable ''
-          nixcord.config.plugins.automodContext is deprecated since it is a discord stock feature and redundant.
-        '')
-        (mkIf cfg.config.plugins.showAllRoles.enable ''
-          nixcord.config.plugins.showAllRoles is deprecated since it is a discord stock feature and redundant.
-        '')
-        (mkIf cfg.config.plugins.timeBarAllActivities.enable ''
-          nixcord.config.plugins.timeBarAllActivities is deprecated since it is a discord stock feature and redundant.
-        '')
-        (mkIf cfg.config.plugins.noDefaultHangStatus.enable ''
-          nixcord.config.plugins.noDefaultHangStatus is deprecated since discord fixed this issue and removed the hang status.
-        '')
-      ];
+      warnings = import ./warnings.nix { inherit cfg mkIf; };
     }
   ]);
 }

--- a/plugins.nix
+++ b/plugins.nix
@@ -442,6 +442,14 @@ with lib;
     enable = mkEnableOption ''
       Disables annoying console messages/errors
     '';
+    disableLoggers = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Disables Discords loggers
+      '';
+    };
+    # deprecated
     disableNoisyLoggers = mkEnableOption ''
       Disable noisy loggers like the MessageActionCreators
     '';
@@ -450,6 +458,13 @@ with lib;
       default = true;
       description = ''
         Disable the Spotify logger, which leaks account information and access token
+      '';
+    };
+    whitelistedLoggers = mkOption {
+      type = types.str;
+      default = "GatewaySocket; Routing/Utils";
+      descrption = ''
+        Semi colon separated list of loggers to allow even if others are hidden
       '';
     };
   };
@@ -902,6 +917,11 @@ with lib;
   friendsSince = {
     enable = mkEnableOption ''
       Shows when you became friends with someone in the user popout
+    '';
+  };
+  fullSearchContext = {
+    enable = mkEnableOption ''
+      Makes the message context menu in message search results have all options you'd expect
     '';
   };
   gameActivityToggle = {
@@ -2334,7 +2354,19 @@ with lib;
         Show role colors in the reactors list
       '';
     };
+    colorChatMessages = mkEnableOption ''
+      Color chat messages based on the author's role color
+    '';
+    messageSaturation = mkOption {
+      type = types.int;
+      default = 30;
+      description = ''
+        Intensity of message coloring.
+      '';
+    };
   };
+  # deprecated
+  # TODO remove after some time
   searchReply = {
     enable = mkEnableOption ''
       Adds a reply button to search results
@@ -2840,8 +2872,24 @@ with lib;
         Show a user's voice channel in their profile modal
       '';
     };
+    showInMemberList = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Show a user's Voice Channel indicator in the member and DMs list
+      '';
+    };
+    showInMessages = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Show a user's Voice Channel indicator in messages
+      '';
+    };
+    # deprecated
     showVoiceChannelSectionHeader = mkOption {
       type = types.bool;
+      # left true, warning if its false
       default = true;
       description = ''
         Whether to show "IN A VOICE CHANNEL" above the join button

--- a/plugins.nix
+++ b/plugins.nix
@@ -463,7 +463,7 @@ with lib;
     whitelistedLoggers = mkOption {
       type = types.str;
       default = "GatewaySocket; Routing/Utils";
-      descrption = ''
+      description = ''
         Semi colon separated list of loggers to allow even if others are hidden
       '';
     };

--- a/vencord.nix
+++ b/vencord.nix
@@ -1,0 +1,107 @@
+# Made from nixpkgs pkg and updated with nix-update
+# identical to nixpkgs source, but maintained here for
+# quicker updates that don't wait on hydra
+
+{
+  curl,
+  esbuild,
+  fetchFromGitHub,
+  git,
+  jq,
+  lib,
+  nix-update,
+  nodejs,
+  pnpm,
+  stdenv,
+  writeShellScript,
+  buildWebExtension ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vencord";
+  version = "1.10.3";
+
+  src = fetchFromGitHub {
+    owner = "Vendicated";
+    repo = "Vencord";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-PgQz6CNr5wkycSZ/M2saS3VtUQlC2rIolnCJlVPrxo8=";
+  };
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname src;
+
+    hash = "sha256-bosCE9gBFCcM3Ww6sJmhps/cl4lovXKMieYpkqAMst8=";
+  };
+
+  nativeBuildInputs = [
+    git
+    nodejs
+    pnpm.configHook
+  ];
+
+  env = {
+    ESBUILD_BINARY_PATH = lib.getExe (
+      esbuild.overrideAttrs (
+        final: _: {
+          version = "0.15.18";
+          src = fetchFromGitHub {
+            owner = "evanw";
+            repo = "esbuild";
+            rev = "v${final.version}";
+            hash = "sha256-b9R1ML+pgRg9j2yrkQmBulPuLHYLUQvW+WTyR/Cq6zE=";
+          };
+          vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+        }
+      )
+    );
+    VENCORD_REMOTE = "${finalAttrs.src.owner}/${finalAttrs.src.repo}";
+    # TODO: somehow update this automatically
+    VENCORD_HASH = "deadbeef";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run ${if buildWebExtension then "buildWeb" else "build"} \
+      -- --standalone --disable-updater
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist/${lib.optionalString buildWebExtension "chromium-unpacked/"} $out
+
+    runHook postInstall
+  '';
+
+  # We need to fetch the latest *tag* ourselves, as nix-update can only fetch the latest *releases* from GitHub
+  # Vencord had a single "devbuild" release that we do not care about
+  passthru.updateScript = writeShellScript "update-vencord" ''
+    export PATH="${
+      lib.makeBinPath [
+        curl
+        jq
+        nix-update
+      ]
+    }:$PATH"
+    ghTags=$(curl ''${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "https://api.github.com/repos/Vendicated/Vencord/tags")
+    latestTag=$(echo "$ghTags" | jq -r .[0].name)
+
+    echo "Latest tag: $latestTag"
+
+    exec nix-update --version "$latestTag" "$@"
+  '';
+
+  meta = with lib; {
+    description = "Vencord web extension";
+    homepage = "https://github.com/Vendicated/Vencord";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [
+      FlafyDev
+      NotAShelf
+      Scrumplex
+    ];
+  };
+})

--- a/warnings.nix
+++ b/warnings.nix
@@ -1,0 +1,45 @@
+{cfg, mkIf}:
+[
+  (mkIf (cfg.config.notifyAboutUpdates || cfg.config.autoUpdate || cfg.config.autoUpdateNotification) ''
+    Nixcord is now pinned to a specific Vencord version to ensure compatability. Config options relating to auto-update no longer function. To update Nixcord to the latest version, use nixos-rebuild
+  '')
+  (mkIf (!builtins.isNull cfg.package) ''
+    nixcord.package has been moved to nixcord.discord.package
+  '')
+  (mkIf (!builtins.isNull cfg.vencord.enable) ''
+    nixcord.vencord has been moved to nixcord.discord.vencord
+  '')
+  (mkIf (!builtins.isNull cfg.openASAR.enable) ''
+    nixcord.openASAR has been moved to nixcord.discord.openASAR
+  '')
+  (mkIf (!builtins.isNull cfg.vesktopPackage) ''
+    nixcord.vesktopPackage has been moved to nixcord.vesktop.package
+  '')
+  (mkIf (!builtins.isNull cfg.config.plugins.ignoreActivities.allowedIds) ''
+    nixcord.config.plugins.ignoreActivities.allowedIds is deprecated and replaced by nixcord.config.plugins.ignoreActivities.idsList
+  '')
+  (mkIf cfg.config.plugins.watchTogetherAdblock.enable ''
+    nixcord.config.plugins.watchTogetherAdblock is deprecated and replaced by nixcord.config.plugins.youtubeAdblock which provides more functionality
+  '')
+  (mkIf cfg.config.plugins.maskedLinkPaste.enable ''
+    nixcord.config.plugins.maksedLinkPaste is deprecated since it is a discord stock feature and redundant.
+  '')
+  (mkIf cfg.config.plugins.automodContext.enable ''
+    nixcord.config.plugins.automodContext is deprecated since it is a discord stock feature and redundant.
+  '')
+  (mkIf cfg.config.plugins.showAllRoles.enable ''
+    nixcord.config.plugins.showAllRoles is deprecated since it is a discord stock feature and redundant.
+  '')
+  (mkIf cfg.config.plugins.timeBarAllActivities.enable ''
+    nixcord.config.plugins.timeBarAllActivities is deprecated since it is a discord stock feature and redundant.
+  '')
+  (mkIf cfg.config.plugins.noDefaultHangStatus.enable ''
+    nixcord.config.plugins.noDefaultHangStatus is deprecated since discord fixed this issue and removed the hang status.
+  '')
+  (mkIf (!cfg.config.plugins.userVoiceShow.showVoiceChannelSectionHeader) ''
+    nixcord.config.plugins.userVoiceShow.showVoiceChannelSectionHeader is deprecated.
+  '')
+  (mkIf cfg.config.plugins.searchReply.enable ''
+    nixcord.config.plugins.searchReply is deprecated. Plugin has been renamed fullSearchContext
+  '')
+]


### PR DESCRIPTION
This took longer than I wanted, sorry abt that.
This should fix several errors and adds a couple new plugins/changes some options.

I tried to impliment a lockfile to lock the discord package for only this module, but it seems this isn't supported well, and I couldn't find any good examples how to do this without changing the module to inputs.nixcord.homeMangerModules.x86_64-linux.nixcord, which Id like to avoid and don't see any other modules doing. If possible Id like to avoid the system here and have it somewhere else, but this presents a lot of issues.