### PR TITLE
Fix plugin name (plugins.nix)

### DIFF
--- a/plugins.nix
+++ b/plugins.nix
@@ -41,7 +41,7 @@ with lib;
     type = types.bool;
     default = true;
   };
-  accountPanelServiceIcon = {
+  accountPanelServerProfile = {
     enable = mkEnableOption ''
       Right click your account panel in the bottom left to
       view your profile in the current server


### PR DESCRIPTION
Change accountPanelServerProfile plugin option to be accurate with docs: https://github.com/KaylorBen/nixcord/blob/main/docs/plugins.md#accountpanelserverprofile

Don't see anymore typos. Love your project!