### PR TITLE
{docs/main.md,hm-module}: `builtins.getEnv "HOME"` -> `config.home.homeDirectory`

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -19,7 +19,7 @@ programs.nixcord.discord.configDir
     # path to discord config
     # this is only useful for changing discord/settings.json
     # type: path
-    # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/discord
+    # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${config.home.homeDirectory}/Library/Application Support"}/discord
 programs.nixcord.discord.vencord.enable
     # whether to install vencord for discord
     # default: true
@@ -37,14 +37,14 @@ programs.nixcord.vesktop.package
 programs.nixcord.vesktop.configDir
     # path to vesktop config
     # type: path
-    # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/vesktop
+    # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${config.home.homeDirectory}/Library/Application Support"}/vesktop
 ```
 ## configDir
 ```nix
 programs.nixcord.configDir
     # path to vencord config
     # type: path
-    # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/Vencord
+    # default: ${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${config.home.homeDirectory}/Library/Application Support"}/Vencord
 ```
 ## quickCss
 ```nix

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -46,7 +46,7 @@ in {
       };
       configDir = mkOption {
         type = types.path;
-        default = "${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/discord";
+        default = "${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${config.home.homeDirectory}/Library/Application Support"}/discord";
         description = "Config path for Discord";
       };
       vencord.enable = mkOption {
@@ -80,7 +80,7 @@ in {
       };
       configDir = mkOption {
         type = types.path;
-        default = "${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/vesktop";
+        default = "${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${config.home.homeDirectory}/Library/Application Support"}/vesktop";
         description = "Config path for Vesktop";
       };
       settings = mkOption {
@@ -115,7 +115,7 @@ in {
     };
     configDir = mkOption {
       type = types.path;
-      default = "${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${builtins.getEnv "HOME"}/Library/Application Support"}/Vencord";
+      default = "${if pkgs.stdenvNoCC.isLinux then config.xdg.configHome else "${config.home.homeDirectory}/Library/Application Support"}/Vencord";
       description = "Vencord config directory";
     };
     vesktopConfigDir = mkOption {


### PR DESCRIPTION
Move away from relying on environment variables that might or might not
be available in a build environment and instead use an abstraction to
get the user directory