### PR TITLE
1.10.5 Update + PNPM hash update

### DIFF
--- a/vencord.nix
+++ b/vencord.nix
@@ -18,19 +18,19 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vencord";
-  version = "1.10.4";
+  version = "1.10.5";
 
   src = fetchFromGitHub {
     owner = "Vendicated";
     repo = "Vencord";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lAMcvJzKFpIvA4QzCnhJddu8EL2SE4iYNvkqesHzsb8=";
+    hash = "sha256-pzb2x5tTDT6yUNURbAok5eQWZHaxP/RUo8T0JECKHJ4=";
   };
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname src;
 
-    hash = "sha256-bosCE9gBFCcM3Ww6sJmhps/cl4lovXKMieYpkqAMst8=";
+    hash = "sha256-YBWe4MEmFu8cksOIxuTK0deO7q0QuqgOUc9WkUNBwp0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
I kept getting this error:
`ERR_PNPM_NO_OFFLINE_TARBALL A package is missing from the store but cannot download it in offline mode. The missing package may be downloaded from https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz.`

Updating pnpm.fetchDeps.hash fixed it for me.

Along with that, I have updated vencord to 1.10.5, everything seems to work fine on my system.