### PR TITLE
Add `package` option to `discord.vencord`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ configure once and save it to a git repo.
 > The primary goal of this project is to reduce the need to configure
 > Vencord again on every new system you install.
 
+>[!WARNING]
+> If you're using NixOS 24.05, please set
+> `programs.nixcord.discord.vencord.package` to `pkgs.vencord;`
+> because the `pnpmDeps.hash` differs between NixOS stable and
+> unstable and this repo uses the unstable hash for the
+> Vencord that it provides.
+>
+> Example:
+>
+> ```nix
+> { pkgs, lib, ... }: {
+>   programs.nixcord = {
+>     enable = true;
+>     discord.vencord.package = pkgs.vencord;
+>   };
+> }
+> ```
+
 ## How to use Nixcord
 Currently Nixcord only supports nix flakes as a [home-manager](https://github.com/nix-community/home-manager) module.
 

--- a/docs/main.md
+++ b/docs/main.md
@@ -23,6 +23,11 @@ programs.nixcord.discord.configDir
 programs.nixcord.discord.vencord.enable
     # whether to install vencord for discord
     # default: true
+programs.nixcord.discord.vencord.package
+    # note: applyPostPatch is always used for userPlugins support
+    # vencord package to use with discord
+    # type: package
+    # default: our bundled vencord package
 programs.nixcord.discord.openASAR.enable
     # whether to install OpenASAR with discord
     # default: true


### PR DESCRIPTION
The main motivation for this change is that the `pnpmDeps.hash` currently differs between `nixos-24.05` and `nixos-unstable`

See:
`nixos-24.05`: https://github.com/NixOS/nixpkgs/blob/dba414932936fde69f0606b4f1d87c5bc0003ede/pkgs/by-name/ve/vencord/package.nix#L29
`nixos-unstable`: https://github.com/NixOS/nixpkgs/blob/4aa36568d413aca0ea84a1684d2d46f55dbabad7/pkgs/by-name/ve/vencord/package.nix#L29

This causes issues because if you're using `nixos-24.05` *(aka the stable channel)*, you'll run into `Error ERR_PNPM_NO_OFFLINE_TARBALL`

To work around this issue, I'm exposing a `package` option so users can "bring their own" `vencord` that has the correct hash

This is also a common practice *(especially in home-manager)* to let users "bring their own" package for the `programs`
