### PR TITLE
plugins.nix: `with lib;` -> `let inherit (lib) ...; in ...`

### DIFF
--- a/plugins.nix
+++ b/plugins.nix
@@ -1,5 +1,7 @@
 { lib, ... }:
-with lib;
+let
+  inherit (lib) types mkEnableOption mkOption;
+in
 {
   chatInputButtonAPI.enable = mkOption {
     type = types.bool;


### PR DESCRIPTION
Using `with lib;` is discouraged and is a dangerous practice[^1]

For more details, see:
- https://github.com/NixOS/nixpkgs/issues/208242
- https://nix.dev/guides/best-practices#with-scopes

This PR is more about setting a good example for anyone else looking at the code. Since the repo has a decent number of stargazers, it will be nice to keep the code "tidy" and "modern" for anyone looking to take inspiration from this repo

[^1]: *(even though in this case there isn't an actual issue)*