### PR TITLE
hm-module.nix: drop option `vencord.enable`

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -184,11 +184,6 @@ in
       default = null;
       description = "Config path for Vesktop";
     };
-    vencord.enable = mkOption {
-      type = with types; nullOr bool;
-      default = null;
-      description = "Enable Vencord (for non-vesktop)";
-    };
     openASAR.enable = mkOption {
       type = with types; nullOr bool;
       default = null;


### PR DESCRIPTION
It was already removed in 478435f198b245abe71b5d0dfbb4abb556b298ff but was forgotten to be removed here