### PR TITLE
Add `programs.discord.vencord.unstable`, Add GitHub Workflow for unstable

### DIFF
--- a/.github/workflows/update-vencord-unstable.yaml
+++ b/.github/workflows/update-vencord-unstable.yaml
@@ -1,0 +1,83 @@
+name: Update Vencord Unstable
+
+on:
+  schedule:
+    - cron: "0 */6 * * *" # Every 6 hours
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update Vencord Unstable
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 1
+
+      - uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get old version
+        id: old-version
+        shell: bash
+        run: |
+          if ! OLD_VERSION=$(nix-shell -p gnused coreutils-full --run "sed -n '0,/rev = \"\(.*\)\"/s/.*rev = \"\(.*\)\".*/\1/p' vencord-unstable.nix | head -n1 | cut -c1-7"); then
+            echo "Failed to extract old version"
+            exit 1
+          fi
+          echo "version=$OLD_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update Vencord Unstable
+        id: update
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! ./update-vencord-unstable.sh; then
+            echo "Failed to update Vencord"
+            exit 1
+          fi
+
+      - name: Get new version
+        id: new-version
+        shell: bash
+        run: |
+          if ! NEW_VERSION=$(nix-shell -p gnused coreutils-full --run "sed -n '0,/rev = \"\(.*\)\"/s/.*rev = \"\(.*\)\".*/\1/p' vencord-unstable.nix | head -n1 | cut -c1-7"); then
+            echo "Failed to extract new version"
+            exit 1
+          fi
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Test Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! nix-build -E 'with import <nixpkgs> {}; callPackage ./vencord-unstable.nix {}'; then
+            echo "Build failed"
+            exit 1
+          fi
+          unlink result
+
+      - name: Commit changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: success() && steps.old-version.outputs.version != steps.new-version.outputs.version
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add .
+            git commit -m "vencord-unstable: ${{ steps.old-version.outputs.version }} -> ${{ steps.new-version.outputs.version }}"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/docs/main.md
+++ b/docs/main.md
@@ -28,6 +28,9 @@ programs.nixcord.discord.vencord.package
     # vencord package to use with discord
     # type: package
     # default: our bundled vencord package
+programs.nixcord.discord.vencord.unstable
+    # whether to use the unstable vencord build from master branch
+    # default: false
 programs.nixcord.discord.openASAR.enable
     # whether to install OpenASAR with discord
     # default: true

--- a/update-vencord-unstable.sh
+++ b/update-vencord-unstable.sh
@@ -1,0 +1,42 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p jq gnused gnugrep nix-update
+# shellcheck shell=bash
+
+set -euo pipefail
+
+cleanup() {
+	if [ -f "temp-wrapper.nix" ]; then
+		rm -f "temp-wrapper.nix"
+	fi
+}
+trap cleanup EXIT
+
+NIX_FILE="./vencord-unstable.nix"
+ABS_NIX_FILE=$(realpath "$NIX_FILE")
+
+if [ ! -f "$ABS_NIX_FILE" ]; then
+	echo "Error: File $NIX_FILE does not exist"
+	exit 1
+fi
+
+OWNER=$(grep 'owner = ' "$ABS_NIX_FILE" | sed -E 's/.*owner = "([^"]+)".*/\1/')
+REPO=$(grep 'repo = ' "$ABS_NIX_FILE" | sed -E 's/.*repo = "([^"]+)".*/\1/' | tr -d '\n')
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+	echo "Error: Could not extract owner/repo from $ABS_NIX_FILE"
+	exit 1
+fi
+
+echo "Updating $ABS_NIX_FILE for $OWNER/$REPO..."
+
+cat >temp-wrapper.nix <<EOF
+{ pkgs ? import <nixpkgs> {} }:
+{
+  ${REPO} = pkgs.callPackage ${ABS_NIX_FILE} {};
+}
+EOF
+
+nix-update --version=branch \
+	-f ./temp-wrapper.nix \
+	--override-filename "$ABS_NIX_FILE" \
+	"${REPO}"

--- a/vencord-unstable.nix
+++ b/vencord-unstable.nix
@@ -1,0 +1,81 @@
+{
+  esbuild,
+  fetchFromGitHub,
+  git,
+  lib,
+  nodejs,
+  pnpm,
+  stdenv,
+  buildWebExtension ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vencord";
+  version = "1.10.8-unstable-2024-12-11";
+
+  src = fetchFromGitHub {
+    owner = "Vendicated";
+    repo = "Vencord";
+    rev = "464c4a9b614a93443575acfd160388d3eb09cb2f";
+    hash = "sha256-4G3RUJO7lfHoSdm60SBpLotKpdEzFp8p2hhc3qbmLcc=";
+  };
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname src;
+
+    hash = "sha256-vVzERis1W3QZB/i6SQR9dQR56yDWadKWvFr+nLTQY9Y=";
+  };
+
+  nativeBuildInputs = [
+    git
+    nodejs
+    pnpm.configHook
+  ];
+
+  env = {
+    ESBUILD_BINARY_PATH = lib.getExe (
+      esbuild.overrideAttrs (
+        final: _: {
+          version = "0.15.18";
+          src = fetchFromGitHub {
+            owner = "evanw";
+            repo = "esbuild";
+            rev = "v${final.version}";
+            hash = "sha256-b9R1ML+pgRg9j2yrkQmBulPuLHYLUQvW+WTyR/Cq6zE=";
+          };
+          vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+        }
+      )
+    );
+    VENCORD_REMOTE = "${finalAttrs.src.owner}/${finalAttrs.src.repo}";
+    VENCORD_HASH = "${finalAttrs.version}";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run ${if buildWebExtension then "buildWeb" else "build"} \
+      -- --standalone --disable-updater
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r dist/${lib.optionalString buildWebExtension "chromium-unpacked/"} $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Vencord web extension";
+    homepage = "https://github.com/Vendicated/Vencord";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      donteatoreo
+      FlafyDev
+      NotAShelf
+      Scrumplex
+    ];
+  };
+})


### PR DESCRIPTION
The main motivation is that Discord's updates sometimes break plugins.
When this happens, you're stuck waiting for several steps:

1. Vencord devs to fix the issue
2. A new release to be published
3. Someone to create a nixpkgs PR
4. The PR to be merged
5. The update to reach nixos-unstable and/or nixos-24.{05,11}

At best, this process takes a few days. Sometimes it can stretch to a
week...

To get around this issue, we're letting users to enable `unstable` so
they can use an "unstable" version that bypasses the release wait time.
We only need to wait for Vencord devs to push a fix to master

The workflow will run every 6 hours, which will run
`update-vencord-unstable.sh` to update `vencord-unstable.nix`