### PR TITLE
fix: fix vesktop settings and state file creation

### DIFF
--- a/docs/main.md
+++ b/docs/main.md
@@ -178,9 +178,8 @@ programs.nixcord.parseRules.fakeEnums.four
 ```
 ## settings.json and state.json control
 >[!WARNING]
-> Due to Vencord/Vesktop#220 this will not be possible without upstream changes.
-> Anyways the options are provided in case you figure something out or want to PR
-> Messing with these will likely cause issues since nix store is read only
+> Due to Vencord/Vesktop#220 this will not work unless you are using a version of nixpkgs later than 24.11
+> Otherwise, messing with these will likely cause issues since nix store is read only
 ```nix
 programs.nixcord.discord.settings
     # Settings to be placed in discord.configDir/settings.json

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -373,13 +373,15 @@ in
         }
         # Vesktop Client Settings
         (mkIf (cfg.vesktop.settings != { }) {
-          home.file."${cfg.vesktop.configDir}/settings.json".text =
-            builtins.toJSON mkVencordCfg cfg.vesktopSettings;
+          home.file."${cfg.vesktop.configDir}/settings.json".text = builtins.toJSON (
+            mkVencordCfg cfg.vesktop.settings
+          );
         })
         # Vesktop Client State
         (mkIf (cfg.vesktop.state != { }) {
-          home.file."${cfg.vesktop.configDir}/state.json".text =
-            builtins.toJSON mkVencordCfg cfg.vesktopState;
+          home.file."${cfg.vesktop.configDir}/state.json".text = builtins.toJSON (
+            mkVencordCfg cfg.vesktop.state
+          );
         })
       ]))
       # Warnings


### PR DESCRIPTION
This fixes an error that appears when `programs.nixcord.vesktop.settings` and `programs.nixcord.vesktop.state` are set, which prevents `~/.config/vesktop/settings.json` and `~/.config/vesktop/state.json` from being created.

This does not fix Vesktop crashing when these files are read-only. However, this should no longer be an issue if NixOS/nixpkgs/pull/368221 gets merged.