### PR TITLE
fix: add missing parens for discord settings impl

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -352,8 +352,9 @@ in
         }
         # Client Settings
         (mkIf (cfg.discord.settings != { }) {
-          home.file."${cfg.discord.configDir}/settings.json".text =
-            builtins.toJSON mkVencordCfg cfg.discord.settings;
+          home.file."${cfg.discord.configDir}/settings.json".text = builtins.toJSON (
+            mkVencordCfg cfg.discord.settings
+          );
         })
       ]))
       (mkIf cfg.vesktop.enable (mkMerge [


### PR DESCRIPTION
My config failed to evaluate when setting `cfg.discord.settings`, I saw it was just missing parentheses so I fixed it.