### PR TITLE
hm-module.nix: add `home.activation.disableDiscordUpdates`

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -336,6 +336,11 @@ in
         ];
       }
       (mkIf cfg.discord.enable (mkMerge [
+        {
+          home.activation.disableDiscordUpdates = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+            ${lib.getExe pkgs.discord.passthru.disableBreakingUpdates}
+          '';
+        }
         # QuickCSS
         (mkIf (isQuickCssUsed cfg.vencordConfig) {
           home.file."${cfg.configDir}/settings/quickCss.css".text = cfg.quickCss;


### PR DESCRIPTION
Closes: https://github.com/KaylorBen/nixcord/issues/70

This will automatically run `disable-breaking-updates.py` which disables Discord auto updates

I didn't give an update option since it's basically ***required*** - Discord will just keep nagging you to update otherwise, which breaks Vencord. 

This is even worse on macOS since it's super misleading - it throws a password prompt at you when you start Discord, and if you say no, you get a fake "network" error and have to wait 10 seconds before it lets you in again. This happens every single time you open Discord and it's just awful UX. 

Some people *(like me, lol)* have fallen for that password prompt, and if you do, you end up with completely broken Discord. Then you have to go through this whole thing of disabling nixcord, rebuilding, clearing garbage, enabling nixcord again, and rebuilding one more time.