### PR TITLE
Vencord: Update Hashes

### DIFF
--- a/vencord.nix
+++ b/vencord.nix
@@ -16,7 +16,7 @@
 
 let
   stableVersion = "1.11.4";
-  stableHash = "sha256-plRiQVo6CFTW2xN5Ntziqrg52BPuXAKh8rX80aDhHxM=";
+  stableHash = "sha256-7bFn3+mpiXC4+PGhoJ10QN1oBjj7zS5U2MJf8cJm114=";
   stablePnpmDeps = "sha256-ZUwtNtOmxjhOBpYB7vuytunGBRSuVxdlQsceRmeyhhI=";
 
   unstableVersion = "1.11.4-unstable-2025-02-07";


### PR DESCRIPTION
```
error: hash mismatch in fixed-output derivation '/nix/store/i9s2rihia4dnh4sz7nywhbjix059fk05-source.drv':
        likely URL: https://github.com/Vendicated/Vencord/archive/v1.11.4.tar.gz
         specified: sha256-plRiQVo6CFTW2xN5Ntziqrg52BPuXAKh8rX80aDhHxM=
            got:    sha256-7bFn3+mpiXC4+PGhoJ10QN1oBjj7zS5U2MJf8cJm114=
error: 1 dependencies of derivation '/nix/store/nxy39nhp1x2iagach6gxddd13gzppw12-vencord-1.11.4.drv' failed to build
```