### PR TITLE
vencord/esbuild: Hashes and versions updated.

### DIFF
--- a/vencord.nix
+++ b/vencord.nix
@@ -15,9 +15,9 @@
 }:
 
 let
-  stableVersion = "1.11.4";
-  stableHash = "sha256-7bFn3+mpiXC4+PGhoJ10QN1oBjj7zS5U2MJf8cJm114=";
-  stablePnpmDeps = "sha256-ZUwtNtOmxjhOBpYB7vuytunGBRSuVxdlQsceRmeyhhI=";
+  stableVersion = "1.11.5";
+  stableHash = "sha256-hdlFL95DFVeUs08/wg6EA5CfV6KeUGaS9kcLGRMyNgY=";
+  stablePnpmDeps = "sha256-0afgeJkK0OQWoqF0b8pHPMsiTKox84YmwBhtNWGyVAg=";
 
   unstableVersion = "1.11.4-unstable-2025-02-12";
   unstableRev = "205e07d2c5b908f29d2a463845d7a1417a4678ad";
@@ -50,12 +50,12 @@ stdenv.mkDerivation (finalAttrs: {
     ESBUILD_BINARY_PATH = lib.getExe (
       esbuild.overrideAttrs (
         final: _: {
-          version = "0.15.18";
+          version = "0.25.0";
           src = fetchFromGitHub {
             owner = "evanw";
             repo = "esbuild";
             rev = "v${final.version}";
-            hash = "sha256-b9R1ML+pgRg9j2yrkQmBulPuLHYLUQvW+WTyR/Cq6zE=";
+            hash = "sha256-L9jm94Epb22hYsU3hoq1lZXb5aFVD4FC4x2qNt0DljA=";
           };
           vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
         }


### PR DESCRIPTION
Since the latest version of Discord has broken some Vencord things, I've updated the hash and version of Vencord. Along side as it's required, I've also updated ESBuilds version and hashes.
I've only modified the Stable branch of Vencord.