### PR TITLE
flake.nix: make treefmt-nix reuse nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
-    treefmt-nix.url = "github:numtide/treefmt-nix";
+
+    treefmt-nix =
+    {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =


### PR DESCRIPTION
Better for flake.lock deduplication as a consumer of the flake, so making nixcord use a specific version of nixpkgs will apply that same version to treefmt-nix.