### PR TITLE
hm-module: Add useSystemVencord option to vesktop

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -124,6 +124,11 @@ in
           The Vesktop package to use
         '';
       };
+      useSystemVencord = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Use system Vencord package";
+      };
       configDir = mkOption {
         type = types.path;
         default = "${
@@ -344,7 +349,7 @@ in
           ))
           (mkIf cfg.vesktop.enable (
             cfg.vesktop.package.override {
-              withSystemVencord = true;
+              withSystemVencord = cfg.vesktop.useSystemVencord;
               withMiddleClickScroll = cfg.vesktop.autoscroll.enable;
               inherit vencord;
             }


### PR DESCRIPTION
Add `vesktop.useSystemVencord` option that overrides the vesktop package.

Using system vesktop produces the following error for me:
```bash
› vesktop
Vesktop v1.5.6
(node:62208) UnhandledPromiseRejectionWarning: Error: EROFS: read-only file system, open '/nix/store/6wxxsnak7jhchl7wxhy084k5v04238g4-vencord-1.11.9/package.json'
    at async open (node:internal/fs/promises:639:25)
    at async writeFile (node:internal/fs/promises:1216:14)
    at async Promise.all (index 1)
    at async fo (VCDMain:13:846)
    at async Te (VCDMain:15:4976)
(Use `electron --trace-warnings ...` to show where the warning was created)
(node:62208) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
```