### PR TITLE
Fix hm-module.nix libgbm ordering

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -68,10 +68,11 @@ in
       package = mkOption {
         type = types.package;
         default =
-          pkgs.callPackage ./discord.nix { }
-          // lib.optionalAttrs (
-            pkgs.stdenvNoCC.isLinux && builtins.fromJSON (lib.versions.major lib.version) < 25
-          ) { libgbm = pkgs.mesa; };
+          pkgs.callPackage ./discord.nix (
+            lib.optionalAttrs (
+              pkgs.stdenvNoCC.isLinux && builtins.fromJSON (lib.versions.major lib.version) < 25
+            ) { libgbm = pkgs.mesa; }
+          );
         description = ''
           The Discord package to use
         '';


### PR DESCRIPTION
Order of operations was off for the `libgbm` fix, so it wasn't getting applied.