### PR TITLE
flake.*: switch to `flake-parts`, expose `discord`, `vencord` derivations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,13 +14,31 @@
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748162331,
-        "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
+        "lastModified": 1748437600,
+        "narHash": "sha256-hYKMs3ilp09anGO7xzfGs3JqEgUqFMnZ8GMAqI6/k04=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7c43f080a7f28b2774f3b3f43234ca11661bf334",
+        "rev": "7282cb574e0607e65224d33be8241eae7cfe0979",
         "type": "github"
       },
       "original": {
@@ -30,9 +48,25 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,18 +1,31 @@
 {
   inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
   };
 
-  outputs = inputs: {
-    homeManagerModules = inputs.nixpkgs.lib.mapAttrs (
-      name:
-      inputs.nixpkgs.lib.warn "Obsolete Flake attribute `nixcord.homeManagerModules.${name}' is used. It was renamed to `nixcord.homeModules.${name}`'."
-    ) inputs.self.homeModules;
-
-    homeModules = {
-      default = inputs.self.homeModules.nixcord;
-      nixcord = import ./hm-module.nix;
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      perSystem =
+        { pkgs, system, ... }:
+        {
+          packages.discord = pkgs.callPackage ./discord.nix { };
+          packages.vencord = pkgs.callPackage ./vencord.nix { };
+        };
+      flake = {
+        homeModules = {
+          default = inputs.self.homeModules.nixcord;
+          nixcord = import ./hm-module.nix;
+        };
+      };
     };
-  };
 }


### PR DESCRIPTION
This will make it possible to to "grab" either the `discord` or `vencord`
derivation that nixcord uses and override it

For example adding additional `--add-flags`  for `discord`