### PR TITLE
flake: remove flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,24 +14,6 @@
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1749494155,
@@ -48,25 +30,9 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,64 +1,78 @@
 {
   inputs = {
-    flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
   };
 
   outputs =
     inputs:
-    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
-      imports = [ ];
+    let
+      inherit (inputs.nixpkgs) lib;
+
       systems = [
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
         "x86_64-darwin"
       ];
-      perSystem =
-        { pkgs, system, ... }:
+
+      # We need unfree for stuff like discord, even though `import nixpkgs` is
+      # slower than direct access to the attrs
+      forAllSystems =
+        function:
+        lib.genAttrs systems (
+          system:
+          function (
+            import inputs.nixpkgs {
+              inherit system;
+              config.allowUnfree = true;
+            }
+          )
+        );
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
+        let
+          docs = import ./docs {
+            inherit pkgs;
+            lib = pkgs.lib;
+          };
+        in
         {
-          _module.args.pkgs = import inputs.nixpkgs {
-            inherit system;
-            config.allowUnfree = true;
-          };
+          discord = pkgs.callPackage ./pkgs/discord.nix { };
+          dorion = pkgs.callPackage ./pkgs/dorion.nix { };
+          vencord = pkgs.callPackage ./pkgs/vencord.nix { };
+          docs-html = docs.html;
+          docs-json = docs.json;
+        }
+      );
 
-          packages = {
-            discord = pkgs.callPackage ./pkgs/discord.nix { };
-            dorion = pkgs.callPackage ./pkgs/dorion.nix { };
-            vencord = pkgs.callPackage ./pkgs/vencord.nix { };
-            docs-html =
-              (import ./docs {
-                inherit pkgs;
-                lib = pkgs.lib;
-              }).html;
-            docs-json =
-              (import ./docs {
-                inherit pkgs;
-                lib = pkgs.lib;
-              }).json;
-          };
+      apps = forAllSystems (pkgs: {
+        docs = {
+          type = "app";
+          program =
+            let
+              docs-html = inputs.self.packages.${pkgs.system}.docs-html;
+              script = # bash
+                ''
+                  if command -v xdg-open >/dev/null 2>&1; then
+                    xdg-open "${docs-html}/share/doc/nixcord/index.xhtml"
+                  elif command -v open >/dev/null 2>&1; then
+                    open "${docs-html}/share/doc/nixcord/index.xhtml"
+                  else
+                    echo "Documentation available at: ${docs-html}/share/doc/nixcord/index.xhtml"
+                  fi
+                '';
+            in
+            pkgs.writeShellScript "open-docs" script;
+        };
+      });
 
-          apps.docs = {
-            type = "app";
-            program = "${pkgs.writeShellScript "open-docs" ''
-              if command -v xdg-open >/dev/null 2>&1; then
-                xdg-open "${inputs.self.packages.${system}.docs-html}/share/doc/nixcord/index.xhtml"
-              elif command -v open >/dev/null 2>&1; then
-                open "${inputs.self.packages.${system}.docs-html}/share/doc/nixcord/index.xhtml"
-              else
-                echo "Documentation available at: ${
-                  inputs.self.packages.${system}.docs-html
-                }/share/doc/nixcord/index.xhtml"
-              fi
-            ''}";
-          };
-        };
-      flake = {
-        homeModules = {
-          default = inputs.self.homeModules.nixcord;
-          nixcord = import ./modules/hm-module.nix;
-        };
+      homeModules = {
+        default = inputs.self.homeModules.nixcord;
+        nixcord = ./modules/hm-module.nix;
       };
+
     };
 }


### PR DESCRIPTION
No ill will to `flake-parts` - I far prefer it over `flake-utils` for personal configurations - but for a project that's meant to be used as a dependency, it requires the user to add it into their system closure, which just leads to the accumulation of `flake.lock` bloat.

The only worry I have is whether the new `homeModules` setup will actually use the correct version of `pkgs` that has unfree set up. Not quite sure how to best test this - would appreciate guidance in this department.