### PR TITLE
add pnpm fetcher version argument to pnpm_10.fetchdeps

### DIFF
--- a/pkgs/vencord.nix
+++ b/pkgs/vencord.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = pnpm_10.fetchDeps {
     inherit (finalAttrs) pname src;
     hash = if unstable then unstablePnpmDeps else stablePnpmDeps;
+    fetcherVersion = 9;
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
fixes #120

as of https://github.com/NixOS/nixpkgs/pull/422975 the arguement `fetcherVersion` is required

thank you @kilanar for the info on fixing this! going though and doing this on a few repos