### PR TITLE
Fix `disableDiscordUpdates` trying to patch without a possible non-created directory for `configDir`

### DIFF
--- a/modules/hm-module.nix
+++ b/modules/hm-module.nix
@@ -585,11 +585,11 @@ in
         {
           home.activation.disableDiscordUpdates = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
             set -euo pipefail
+            mkdir -p "${cfg.discord.configDir}"
             config_dir="${cfg.discord.configDir}"
             if [ -f "$config_dir/settings.json" ]; then
               jq '. + {"SKIP_HOST_UPDATE": true}' "$config_dir/settings.json" > "$config_dir/settings.json.tmp" && mv "$config_dir/settings.json.tmp" "$config_dir/settings.json"
             else
-              mkdir -p $config_dir
               echo '{"SKIP_HOST_UPDATE": true}' > "$config_dir/settings.json"
             fi
           '';

--- a/modules/hm-module.nix
+++ b/modules/hm-module.nix
@@ -589,6 +589,7 @@ in
             if [ -f "$config_dir/settings.json" ]; then
               jq '. + {"SKIP_HOST_UPDATE": true}' "$config_dir/settings.json" > "$config_dir/settings.json.tmp" && mv "$config_dir/settings.json.tmp" "$config_dir/settings.json"
             else
+              mkdir -p $config_dir
               echo '{"SKIP_HOST_UPDATE": true}' > "$config_dir/settings.json"
             fi
           '';


### PR DESCRIPTION
This PR aims to fix the issue where if the parent directories of the config don't exist it doesn't build and instead errors saying 'File not found'

A way to reproduce the issue with upstream on macOS is deleting `~/Library/Application Support/discord/` (which is the state when using home-manager before installing Discord), then rebuild then your rebuild will fail in a weird way, not giving a red error assertion, which is what most people look for, and might get confused.  
<img width="884" height="85" alt="image" src="https://github.com/user-attachments/assets/467d1bdf-37f0-449c-bbfd-bb7957474987" />