### PR TITLE
🐛 right definition ++ readOnly

### DIFF
--- a/modules/hm-module.nix
+++ b/modules/hm-module.nix
@@ -551,20 +551,20 @@ in
     finalPackage = {
       discord = mkOption {
         type = with types; package;
+        readOnly = true;
         description = "The final discord package that is created";
-        default = null;
       };
 
       vesktop = mkOption {
         type = with types; package;
+        readOnly = true;
         description = "The final vesktop package that is created";
-        default = null;
       };
       
       dorion = mkOption {
         type = with types; package;
+        readOnly = true;
         description = "The final dorion package that is created";
-        default = null;
       };
     };
   };
@@ -592,7 +592,7 @@ in
           }
         ];
         
-        cfg.finalPackage.discord = 
+        programs.nixcord.finalPackage.discord = 
           cfg.discord.package.override ({
             withVencord = cfg.discord.vencord.enable;
             withOpenASAR = cfg.discord.openASAR.enable;
@@ -601,14 +601,14 @@ in
             inherit vencord;
           });
 
-        cfg.finalPackage.vesktop = 
+        programs.nixcord.finalPackage.vesktop = 
           cfg.vesktop.package.override {
             withSystemVencord = cfg.vesktop.useSystemVencord;
             withMiddleClickScroll = cfg.vesktop.autoscroll.enable;
             inherit vencord;
           };
 
-        cfg.finalPackage.dorion = cfg.dorion.package;
+        programs.nixcord.finalPackage.dorion = cfg.dorion.package;
 
         home.packages = [
           (mkIf cfg.discord.enable cfg.finalPackage.discord)


### PR DESCRIPTION
Fixed config being called (fixes #131)
also added a readOnly option for the finished packages

---
(last time I could not check on my own configuration, this time the entire system can build with the modules)
(sorry for the inconvenience)