### PR TITLE
Remove withSystemEquicord from equibop override

### DIFF
--- a/modules/lib/core.nix
+++ b/modules/lib/core.nix
@@ -95,7 +95,6 @@ let
       equibop =
         if cfg.equibop.package != null then
           cfg.equibop.package.override {
-            withSystemEquicord = cfg.equibop.useSystemEquicord;
             withMiddleClickScroll = cfg.equibop.autoscroll.enable;
             inherit equicord;
           }


### PR DESCRIPTION
Removed 'withSystemEquicord' from equibop package override.

The option "withSystemEquicord" has been removed as of https://github.com/NixOS/nixpkgs/commit/e4e6cc242db3ace23cae472ba60f53a817378e9c
Thus failing to build Equibob:
error: function 'anonymous lambda' called with unexpected argument 'withSystemEquicord'
       at /nix/store/f640ps0hcp7w5jzg18djf8gdhl6r2rnl-source/pkgs/by-name/eq/equibop/package.nix:1:1:
            1| {
             | ^
            2|   lib,
