### PR TITLE
chore(equicord,vencord): use top-level pnpm attrs

### DIFF
--- a/pkgs/equicord.nix
+++ b/pkgs/equicord.nix
@@ -8,6 +8,8 @@
   lib,
   nodejs,
   pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
   stdenv,
   buildWebExtension ? false,
   writeShellApplication,
@@ -36,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit hash;
   };
 
-  pnpmDeps = pnpm_10.fetchDeps {
+  pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
     hash = pnpmDeps;
@@ -45,7 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     git
     nodejs
-    pnpm_10.configHook
+    pnpm_10
+    pnpmConfigHook
   ];
 
   env = {

--- a/pkgs/vencord.nix
+++ b/pkgs/vencord.nix
@@ -11,6 +11,8 @@
   buildWebExtension ? false,
   unstable ? false,
   pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
   writeShellApplication,
   cacert,
   coreutils,
@@ -42,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = if unstable then unstableHash else stableHash;
   };
 
-  pnpmDeps = pnpm_10.fetchDeps {
+  pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname src;
     hash = if unstable then unstablePnpmDeps else stablePnpmDeps;
     fetcherVersion = 2;
@@ -51,7 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     gitMinimal
     nodejs_22
-    pnpm_10.configHook
+    pnpm_10
+    pnpmConfigHook
   ];
 
   env = {


### PR DESCRIPTION
Use the top-level `pnpmConfigHook` and `fetchPnpmDeps` attributes instead of the package attributes `pnpm.configHook` and `pnpm.fetchDeps` which have been deprecated.