### PR TITLE
chore: vencord: fix pnpm hash

### DIFF
--- a/pkgs/vencord.nix
+++ b/pkgs/vencord.nix
@@ -21,7 +21,7 @@
 let
   stableVersion = "1.13.11";
   stableHash = "sha256-PSA1CD5YMDSNrP6JUEfdqSC1fNXXWHKsu5hCXnoXGCA=";
-  stablePnpmDeps = "sha256-103mxmXBupvQ/H7MRPFaAWmHrzYw8r6U10XH4tfmfaY=";
+  stablePnpmDeps = "sha256-K9rjPsODn56kM2k5KZHxY99n8fKvWbRbxuxFpYVXYks=";
 
   unstableVersion = "1.13.11-unstable-2025-12-20";
   unstableRev = "e5df9b394e1183bd76fe0b09efda228063ad4dca";


### PR DESCRIPTION
Vencord is failing to build with:
```bash
error: hash mismatch in fixed-output derivation '/nix/store/yb8fa33hsbhf7gbmjbrz6kqd0hyxf97y-vencord-pnpm-deps.drv':
           likely URL: (unknown)
            specified: sha256-103mxmXBupvQ/H7MRPFaAWmHrzYw8r6U10XH4tfmfaY=
                  got: sha256-K9rjPsODn56kM2k5KZHxY99n8fKvWbRbxuxFpYVXYks=
        expected path: /nix/store/5q3b3i1fha3q9g7hnjk9fxj8fwfnsrjd-vencord-pnpm-deps
             got path: /nix/store/zklcqyi04ky11901lyrvnbfg1hpnpd8h-vencord-pnpm-deps
```