### PR TITLE
feat(oneko): :sparkles: add option for configuring fps

### DIFF
--- a/modules/plugins/shared.nix
+++ b/modules/plugins/shared.nix
@@ -1483,6 +1483,11 @@ in
       description = ''Speed of Da Cat :3'';
       type = types.int;
     };
+    fps = mkOption {
+      default = 24;
+      description = ''Fps of Da Cat :3'';
+      type = types.int;
+    };
   };
   openInApp = {
     enable = mkEnableOption ''Open links in their respective apps instead of your browser (Shared between Vencord and Equicord)'';


### PR DESCRIPTION
On equibop this defaults to 24. This was way too fast for me, so I really wanted a way to declaratively change it