### PR TITLE
modules/hm: fix invalid syntax

### DIFF
--- a/modules/hm/default.nix
+++ b/modules/hm/default.nix
@@ -74,10 +74,10 @@ in
 
       allPlugins =
         cfg.config.plugins
-        // cfg.extraConfig.plugins
-        // cfg.vencordConfig.plugins
-        // cfg.equicordConfig.plugins
-        // cfg.equibopConfig.plugins;
+        // (cfg.extraConfig.plugins or { })
+        // (cfg.vencordConfig.plugins or { })
+        // (cfg.equicordConfig.plugins or { })
+        // (cfg.equibopConfig.plugins or { });
 
       deprecatedPlugins = collectDeprecatedPlugins { plugins = allPlugins; };
     in


### PR DESCRIPTION
```bash
› sudo nixos-rebuild switch --flake .#ryzen
warning: Git tree '/home/amadejk/Documents/dotfiles' is dirty
building the system configuration...
warning: Git tree '/home/amadejk/Documents/dotfiles' is dirty
error:
       … while calling the 'head' builtin
         at /nix/store/kfcxqcxb9hcq6x33sg4cmwakbb1ifwg9-source/lib/attrsets.nix:1713:13:
         1712|           if length values == 1 || pred here (elemAt values 1) (head values) then
         1713|             head values
             |             ^
         1714|           else

       … while evaluating the attribute 'value'
         at /nix/store/kfcxqcxb9hcq6x33sg4cmwakbb1ifwg9-source/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attempt to call something which is not a function but a list: [ «thunk» «thunk» ]
       at /nix/store/yn7vrpglzngxww662q45m73w0wmd6gs9-source/modules/hm/default.nix:85:7:
           84|     mkMerge (
           85|       [
             |       ^
           86|         {
Command 'nix --extra-experimental-features 'nix-command flakes' build --print-out-paths '.#nixosConfigurations."ryzen".config.system.build.toplevel' --no-link' returned non-zero exit status 1.
```