### PR TITLE
fix: do not override equicord in equibop

### DIFF
--- a/modules/lib/core.nix
+++ b/modules/lib/core.nix
@@ -98,7 +98,6 @@ let
         if cfg.equibop.package != null then
           cfg.equibop.package.override {
             withMiddleClickScroll = cfg.equibop.autoscroll.enable;
-            inherit equicord;
           }
         else
           null;


### PR DESCRIPTION
This PR removes the override for equicord in equibop.

Currently, even though the [equibop package in nixpkgs](https://github.com/NixOS/nixpkgs/blob/88d3861acdd3d2f0e361767018218e51810df8a1/pkgs/by-name/eq/equibop/package.nix) has an `equicord` argument, it is completely unused and the package uses its own bundled version of equicord instead.

Furthermore, there is a WIP [PR to update equibop](https://github.com/NixOS/nixpkgs/pull/456790) in nixpkgs that remove the unused equicord argument, which would break nixcord's equibop support.