### PR TITLE
fix: use top-level pnpmConfigHook and fetchPnpmDeps

### DIFF
--- a/pkgs/equicord.nix
+++ b/pkgs/equicord.nix
@@ -4,6 +4,8 @@
   lib,
   nodejs,
   pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
   stdenv,
   buildWebExtension ? false,
   writeShellApplication,
@@ -32,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit hash;
   };
 
-  pnpmDeps = pnpm_10.fetchDeps {
+  pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     hash = pnpmDeps;
     fetcherVersion = 2;
@@ -42,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     git
     nodejs
     pnpm_10
-    pnpm_10.configHook
+    pnpmConfigHook
   ];
 
   env = {

--- a/pkgs/vencord.nix
+++ b/pkgs/vencord.nix
@@ -7,6 +7,8 @@
   buildWebExtension ? false,
   unstable ? false,
   pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
   writeShellApplication,
   cacert,
   coreutils,
@@ -45,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '"@types/react": "18.3.1"' '"@types/react": "19.0.12"'
   '';
 
-  pnpmDeps = pnpm_10.fetchDeps {
+  pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
       pname
       src
@@ -60,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     gitMinimal
     nodejs_22
     pnpm_10
-    pnpm_10.configHook
+    pnpmConfigHook
   ];
 
   env = {


### PR DESCRIPTION
`pnpm.fetchDeps` and `pnpm.configHook` are now deprecated and are replaced with top-level attributes `fetchPnpmDeps` and `pnpmConfigHook` respectively. See https://github.com/NixOS/nixpkgs/pull/469437.