### PR TITLE
fix(equicord): update pnpm dependency hash

### DIFF
--- a/pkgs/equicord.nix
+++ b/pkgs/equicord.nix
@@ -17,7 +17,7 @@ let
   version = "v1.14.3.1";
   hash = "sha256-JGzzT0HXkopUVocgtz3cSQBD69W+PPFZqWrfJth12uo=";
   pnpmDepsHashDarwin = "sha256-jxJhDhfXWtQND4luaGmmIIIfnqFkXw2T3zdOSKcna68=";
-  pnpmDepsHashLinux = "sha256-AuHNcHosbYlPXKT0YFTLQihbTjff0Z9SlhoV1LDZc7c=";
+  pnpmDepsHashLinux = "sha256-4mpqjkCCCjzNpLns6Q3TDBqf29wg0jooRnz8nnJRlN4=";
   pnpmDepsHash = if stdenvNoCC.isDarwin then pnpmDepsHashDarwin else pnpmDepsHashLinux;
   owner = equicord.src.owner;
   repo = equicord.src.repo;


### PR DESCRIPTION
Fixes a hash mismatch in the equicord-pnpm-deps fixed-output derivation.

Build was failing with:
```
error: hash mismatch in fixed-output derivation '/nix/store/x224i3w6dgxg7f55282p1mqgl9r4iigf-equicord-pnpm-deps.drv':
         specified: sha256-AuHNcHosbYlPXKT0YFTLQihbTjff0Z9SlhoV1LDZc7c=
         got:      sha256-4mpqjkCCCjzNpLns6Q3TDBqf29wg0jooRnz8nnJRlN4=
```