### PR TITLE
fix(equicord): pnpm hash - undo ecdb0fc

### DIFF
--- a/pkgs/equicord.nix
+++ b/pkgs/equicord.nix
@@ -17,7 +17,7 @@ let
   version = "v1.14.3.1";
   hash = "sha256-JGzzT0HXkopUVocgtz3cSQBD69W+PPFZqWrfJth12uo=";
   pnpmDepsHashDarwin = "sha256-jxJhDhfXWtQND4luaGmmIIIfnqFkXw2T3zdOSKcna68=";
-  pnpmDepsHashLinux = "sha256-4mpqjkCCCjzNpLns6Q3TDBqf29wg0jooRnz8nnJRlN4=";
+  pnpmDepsHashLinux = "sha256-AuHNcHosbYlPXKT0YFTLQihbTjff0Z9SlhoV1LDZc7c=";
   pnpmDepsHash = if stdenvNoCC.isDarwin then pnpmDepsHashDarwin else pnpmDepsHashLinux;
   owner = equicord.src.owner;
   repo = equicord.src.repo;


### PR DESCRIPTION
Undoes ecdb0fc. Something has changed in the last 13 hours which causes the sha256 from ecdb0fc to be invalid after doing `nix flake update`.

I have checked both home-manager and nixos system wide and get the same error for both, as well I have also checked to see if the error still happens when nixcord follows the unstable branch for nixpkgs, and it does. 

```nix
error: hash mismatch in fixed-output derivation '/nix/store/k3wyvjh5s85l5apxd306rgihfx6l0f9h-equicord-pnpm-deps.drv':
         specified: sha256-4mpqjkCCCjzNpLns6Q3TDBqf29wg0jooRnz8nnJRlN4=
            got:    sha256-AuHNcHosbYlPXKT0YFTLQihbTjff0Z9SlhoV1LDZc7c=
error: Cannot build '/nix/store/65c5a524k55xmhvlmwzjancsk6knf9br-equicord-v1.14.3.1.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/ii98ksv0x5z8s5r8ka1mba4k7k7k0vd1-equicord-v1.14.3.1
error: Cannot build '/nix/store/akg69kk3zwwx4q6z44ddq9y5simlvpsp-discord-0.0.127.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/2ci3w62x5blx82njc3k5yvyzb2ingd6h-discord-0.0.127
```