### PR TITLE
feat: added global package set option

### DIFF
--- a/modules/options/default.nix
+++ b/modules/options/default.nix
@@ -32,6 +32,18 @@ in
 
     enable = mkEnableOption "nixcord (Discord with Vencord/Equicord)";
 
+    useGlobalPkgs = mkOption {
+      type = types.bool;
+      default = false;
+      example = true;
+      description = ''
+        Whether to build Nixcord-provided packages with the package set passed
+        to the module instead of Nixcord's pinned package set. This may reduce
+        evaluation overhead, but uses a package combination that Nixcord does
+        not test.
+      '';
+    };
+
     configDir = mkOption {
       type = types.path;
       description = "Config directory for the selected client (Vencord or Equicord).";

--- a/modules/options/discord.nix
+++ b/modules/options/discord.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   nixcordPkgs ? { },
@@ -10,6 +11,7 @@ let
   vencordPackage = pkgs.callPackage ../../pkgs/vencord.nix { };
   equicordPackage = pkgs.callPackage ../../pkgs/equicord.nix { };
   openasarPackage = pkgs.callPackage ../../pkgs/openasar.nix { };
+  selectedNixcordPkgs = if config.programs.nixcord.useGlobalPkgs then { } else nixcordPkgs;
 in
 {
   options.programs.nixcord.discord = {
@@ -28,7 +30,7 @@ in
       type = types.package;
       default = pkgs.callPackage ../../pkgs/discord (
         {
-          openasar = nixcordPkgs.openasar or openasarPackage;
+          openasar = selectedNixcordPkgs.openasar or openasarPackage;
         }
         // lib.optionalAttrs (pkgs.stdenvNoCC.isLinux && lib.versionOlder lib.version "25") {
           libgbm = pkgs.mesa;
@@ -60,7 +62,7 @@ in
       };
       package = mkOption {
         type = types.package;
-        default = nixcordPkgs.vencord or vencordPackage;
+        default = selectedNixcordPkgs.vencord or vencordPackage;
         defaultText = lib.literalExpression "pkgs.callPackage ../../pkgs/vencord.nix { }";
         description = "The Vencord package to use.";
       };
@@ -69,7 +71,7 @@ in
       enable = mkEnableOption "Equicord (alternative to Vencord)";
       package = mkOption {
         type = types.package;
-        default = nixcordPkgs.equicord or equicordPackage;
+        default = selectedNixcordPkgs.equicord or equicordPackage;
         defaultText = lib.literalExpression "pkgs.callPackage ../../pkgs/equicord.nix { }";
         description = "The Equicord package to use.";
       };


### PR DESCRIPTION
Added `programs.nixcord.useGlobalPkgs` to reuse the module’s existing package set which avoids an additional nixpkgs evaluation. This reduced my evaluation time by about 3.5 seconds. It defaults to `false`.